### PR TITLE
Add IME wrapper to handle IME input 

### DIFF
--- a/src/main/java/org/lwjglx/input/Keyboard.java
+++ b/src/main/java/org/lwjglx/input/Keyboard.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 
 import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.glfw.GLFW;
@@ -158,8 +160,7 @@ public class Keyboard {
     public static final int KEY_SLEEP = 0xDF;
 
     public static final int keyCount;
-
-    private static EventQueue queue = new EventQueue(128);
+    private static final Queue<KeyEvent> queue = new ArrayBlockingQueue<>(128);
 
     private enum KeyState {
 
@@ -175,16 +176,6 @@ public class Keyboard {
     }
 
     private static boolean doRepeatEvents = true;
-
-    private static int[] keyEvents = new int[queue.getMaxEvents()];
-    private static KeyState[] keyEventStates = new KeyState[queue.getMaxEvents()];
-
-    static {
-        Arrays.fill(keyEventStates, KeyState.RELEASE);
-    }
-
-    private static long[] nanoTimeEvents = new long[queue.getMaxEvents()];
-    private static char[] keyEventChars = new char[Short.MAX_VALUE];
 
     public static final int KEYBOARD_SIZE = Short.MAX_VALUE;
 
@@ -217,10 +208,7 @@ public class Keyboard {
             }
             keyMap.put(keyName[i], i);
         }
-        for (int key = 32; key < 128; key++) {
-            keyEventChars[KeyCodes.toLwjglKey(key)] = (char) key;
-        }
-        keyEventChars[KEY_NONE] = '\0';
+        queue.add(new KeyEvent(0, '\0', KeyState.RELEASE, Sys.getNanoTime()));
     }
 
     public static void addGlfwKeyEvent(long window, int key, int scancode, int action, int mods) {
@@ -236,24 +224,16 @@ public class Keyboard {
             }
             default -> state = KeyState.RELEASE;
         }
-        keyEvents[queue.getNextPos()] = KeyCodes.toLwjglKey(key);
-        keyEventStates[queue.getNextPos()] = state;
-        nanoTimeEvents[queue.getNextPos()] = Sys.getNanoTime();
 
-        queue.add();
+        queue.add(new KeyEvent(KeyCodes.toGlfwKey(key), '\0', state, Sys.getNanoTime()));
     }
 
     public static void addKeyEvent(int key, boolean pressed) {
-        keyEvents[queue.getNextPos()] = KeyCodes.toLwjglKey(key);
-        keyEventStates[queue.getNextPos()] = pressed ? KeyState.PRESS : KeyState.RELEASE;
-        nanoTimeEvents[queue.getNextPos()] = Sys.getNanoTime();
-
-        queue.add();
+        queue.add(new KeyEvent(key, '\0', pressed ? KeyState.PRESS : KeyState.RELEASE, Sys.getNanoTime()));
     }
 
     public static void addCharEvent(int key, char c) {
-        int index = KeyCodes.toLwjglKey(key);
-        keyEventChars[index] = c;
+        queue.add(new KeyEvent(KEY_NONE, c, KeyState.PRESS, Sys.getNanoTime()));
     }
 
     public static void create() throws LWJGLException {}
@@ -279,31 +259,35 @@ public class Keyboard {
     }
 
     public static int getNumKeyboardEvents() {
-        return queue.getEventCount();
+        return queue.size();
     }
 
     public static boolean isRepeatEvent() {
-        return keyEventStates[queue.getCurrentPos()] == KeyState.REPEAT;
+        return queue.peek().state == KeyState.REPEAT;
     }
 
     public static boolean next() {
-        return queue.next();
+        boolean next = queue.size() > 1;
+        if (next) {
+            queue.remove();
+        }
+        return next;
     }
 
     public static int getEventKey() {
-        return keyEvents[queue.getCurrentPos()];
+        return queue.peek().key;
     }
 
     public static char getEventCharacter() {
-        return keyEventChars[getEventKey()];
+        return queue.peek().aChar;
     }
 
     public static boolean getEventKeyState() {
-        return keyEventStates[queue.getCurrentPos()].isPressed;
+        return queue.peek().state.isPressed;
     }
 
     public static long getEventNanoseconds() {
-        return nanoTimeEvents[queue.getCurrentPos()];
+        return queue.peek().nano;
     }
 
     public static String getKeyName(int key) {
@@ -329,4 +313,19 @@ public class Keyboard {
     }
 
     public static void destroy() {}
+
+    private static class KeyEvent {
+
+        public int key;
+        public char aChar;
+        public KeyState state;
+        public long nano;
+
+        KeyEvent(int key, char c, KeyState state, long nano) {
+            this.key = key;
+            this.aChar = c;
+            this.state = state;
+            this.nano = nano;
+        }
+    }
 }

--- a/src/main/java/org/lwjglx/input/Keyboard.java
+++ b/src/main/java/org/lwjglx/input/Keyboard.java
@@ -224,16 +224,21 @@ public class Keyboard {
             }
             default -> state = KeyState.RELEASE;
         }
-
-        queue.add(new KeyEvent(KeyCodes.toGlfwKey(key), '\0', state, Sys.getNanoTime()));
+        try {
+            queue.add(new KeyEvent(KeyCodes.toLwjglKey(key), '\0', state, Sys.getNanoTime()));
+        } catch (IllegalStateException ignored) {}
     }
 
     public static void addKeyEvent(int key, boolean pressed) {
-        queue.add(new KeyEvent(key, '\0', pressed ? KeyState.PRESS : KeyState.RELEASE, Sys.getNanoTime()));
+        try {
+            queue.add(new KeyEvent(key, '\0', pressed ? KeyState.PRESS : KeyState.RELEASE, Sys.getNanoTime()));
+        } catch (IllegalStateException ignored) {}
     }
 
     public static void addCharEvent(int key, char c) {
-        queue.add(new KeyEvent(KEY_NONE, c, KeyState.PRESS, Sys.getNanoTime()));
+        try {
+            queue.add(new KeyEvent(KEY_NONE, c, KeyState.PRESS, Sys.getNanoTime()));
+        } catch (IllegalStateException ignored) {}
     }
 
     public static void create() throws LWJGLException {}

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -139,15 +139,7 @@ public class Display {
 
             @Override
             public void invoke(long window, int key, int scancode, int action, int mods) {
-
-                latestEventKey = key;
-
                 Keyboard.addGlfwKeyEvent(window, key, scancode, action, mods);
-                // Ctrl should generate ASCII modifier keys (0x01-0x1F), glfw does not give use char events for this
-                if ((mods & GLFW_MOD_CONTROL) != 0 && key >= GLFW_KEY_A && key <= GLFW_KEY_Z) {
-                    int codepoint = key & 0x1F;
-                    Keyboard.addCharEvent(key, (char) codepoint);
-                }
             }
         };
 
@@ -155,7 +147,6 @@ public class Display {
 
             @Override
             public void invoke(long window, int codepoint) {
-
                 Keyboard.addCharEvent(latestEventKey, (char) codepoint);
             }
         };


### PR DESCRIPTION
Implementation of three IME wrappers for GuiTextField, GuiEditSign and GuiScreenBook. All of them works by syncing text between gui and swing text component. Should work on modded gui unless they:
 - Override some key methods in GuiTextField without call super
 - Make their own text input handling gui
 - Not using lwjgl input at all