### PR TITLE
Early Event Bus

### DIFF
--- a/src/main/java/com/cleanroommc/event/EarlyBus.java
+++ b/src/main/java/com/cleanroommc/event/EarlyBus.java
@@ -1,6 +1,17 @@
 package com.cleanroommc.event;
 
+import com.cleanroommc.bouncepad.Bouncepad;
+import com.cleanroommc.utils.FileUtil;
 import com.google.common.eventbus.EventBus;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.relauncher.FMLInjectionData;
+import net.minecraftforge.fml.relauncher.libraries.LibraryManager;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * The Event Bus used for early event.
@@ -16,4 +27,38 @@ import com.google.common.eventbus.EventBus;
 **/
 public class EarlyBus {
     public static final EventBus BUS=new EventBus("cleanroom_early_bus");
+    @SuppressWarnings("all")
+    private static void register(){
+        Method m_register;
+        try{
+            Class<?> clazz=Bouncepad.classLoader.findClass("net.minecraftforge.fml.relauncher.IEarlyBusSubscribePlugin");
+            m_register= clazz.getDeclaredMethod("addToBus");
+        } catch (ClassNotFoundException|NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        List<File> file_canidates = LibraryManager.gatherLegacyCanidates((File)FMLInjectionData.data()[6]);
+        List<String> listeners=new LinkedList<>();
+        for(File modSource:file_canidates){
+            byte[] fileByte =FileUtil.getFile(modSource,"META-INF/earlybus.cfg");
+            for(String rawLine:new String(fileByte).split("\n")){
+                String line=rawLine.trim();
+                if (!line.isEmpty()){
+                    listeners.add(line);
+                }
+            }
+        }
+        for(String clazzName:listeners){
+            try {
+                Class<?> clazz=Bouncepad.classLoader.findClass(clazzName);
+                Object instance=clazz.getDeclaredConstructor(new Class[0]).newInstance();
+                m_register.invoke(instance,BUS);
+            } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException |
+                     InvocationTargetException e) {
+                FMLLog.log.error(e);
+            }
+        }
+    }
+    static {
+        register();
+    }
 }

--- a/src/main/java/com/cleanroommc/event/EarlyBus.java
+++ b/src/main/java/com/cleanroommc/event/EarlyBus.java
@@ -1,0 +1,19 @@
+package com.cleanroommc.event;
+
+import com.google.common.eventbus.EventBus;
+
+/**
+ * The Event Bus used for early event.
+ * For example: Transform event, Config event, mod load event...
+ * Because the design. You need to register instances to subscribe the events.
+ * for example:
+ * <pre>
+ *     @ Subscribe
+ *     public void listen(Event event){
+ *         //...
+ *     }
+ * </pre>
+**/
+public class EarlyBus {
+    public static final EventBus BUS=new EventBus("cleanroom_early_bus");
+}

--- a/src/main/java/com/cleanroommc/event/FMLDiscoverModEvent.java
+++ b/src/main/java/com/cleanroommc/event/FMLDiscoverModEvent.java
@@ -5,6 +5,9 @@ import net.minecraftforge.fml.common.discovery.ModDiscoverer;
 
 import java.util.List;
 import java.util.function.Supplier;
+/**
+ * FMLDiscoverModEvent is fired when fml have discovered mods but have not loaded them.
+ */
 
 public record FMLDiscoverModEvent(Supplier<ModDiscoverer> modDiscoverer, Supplier<List<ModContainer>> mods){
 }

--- a/src/main/java/com/cleanroommc/event/FMLDiscoverModEvent.java
+++ b/src/main/java/com/cleanroommc/event/FMLDiscoverModEvent.java
@@ -1,0 +1,10 @@
+package com.cleanroommc.event;
+
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.discovery.ModDiscoverer;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public record FMLDiscoverModEvent(Supplier<ModDiscoverer> modDiscoverer, Supplier<List<ModContainer>> mods){
+}

--- a/src/main/java/com/cleanroommc/event/MixinBootEvent.java
+++ b/src/main/java/com/cleanroommc/event/MixinBootEvent.java
@@ -1,11 +1,13 @@
 package com.cleanroommc.event;
 
-import zone.rong.mixinbooter.ILateMixinLoader;
-
 import java.util.List;
 
-
+/**
+ * MixinBootEvent is fired when MixinBooter gather the MixinLoader
+ * Early - {@link zone.rong.mixinbooter.IEarlyMixinLoader}
+ * Late  - {@link zone.rong.mixinbooter.ILateMixinLoader}
+ */
 public class MixinBootEvent {
     public record Early(List<Object> mixinLoader) { }
-    public record Late(List<ILateMixinLoader> mixinLoader){ }
+    public record Late(List<Object> mixinLoader){ }
 }

--- a/src/main/java/com/cleanroommc/event/MixinBootEvent.java
+++ b/src/main/java/com/cleanroommc/event/MixinBootEvent.java
@@ -4,11 +4,7 @@ import zone.rong.mixinbooter.ILateMixinLoader;
 
 import java.util.List;
 
-/**
- * @Project Cleanroom
- * @Author Hileb
- * @Date 2024/1/8 23:36
- **/
+
 public class MixinBootEvent {
     public record Early(List<Object> mixinLoader) { }
     public record Late(List<ILateMixinLoader> mixinLoader){ }

--- a/src/main/java/com/cleanroommc/event/MixinBootEvent.java
+++ b/src/main/java/com/cleanroommc/event/MixinBootEvent.java
@@ -1,0 +1,15 @@
+package com.cleanroommc.event;
+
+import zone.rong.mixinbooter.ILateMixinLoader;
+
+import java.util.List;
+
+/**
+ * @Project Cleanroom
+ * @Author Hileb
+ * @Date 2024/1/8 23:36
+ **/
+public class MixinBootEvent {
+    public record Early(List<Object> mixinLoader) { }
+    public record Late(List<ILateMixinLoader> mixinLoader){ }
+}

--- a/src/main/java/com/cleanroommc/utils/FileUtil.java
+++ b/src/main/java/com/cleanroommc/utils/FileUtil.java
@@ -1,0 +1,130 @@
+package com.cleanroommc.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.JsonUtils;
+import net.minecraftforge.fml.common.FMLLog;
+import org.apache.commons.io.IOUtils;
+
+import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.CharBuffer;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class FileUtil {
+
+    /**
+     * @param source the jar or the dic
+     * @param path the path of the file.
+     * @return null - if file is not exist.
+     *         byte[] - the file.
+     */
+    @Nullable
+    public static byte[] getFile(File source,String path){
+        FileSystem fs = null;
+        Path fPath = null;
+        if (source.isFile()){
+            try{
+                fs = FileSystems.newFileSystem(source.toPath(), (ClassLoader)null);
+                fPath = fs.getPath("/" + path);
+            }catch (IOException e){
+                FMLLog.log.error("Error loading FileSystem from jar: ", e);
+                return null;
+            }
+        }else if (source.isDirectory()){
+            fPath = source.toPath().resolve(path);
+        }
+        if (fPath != null && Files.exists(fPath))
+        {
+            try
+            {
+                return Files.readAllBytes(fPath);
+            }catch (Exception e){
+                FMLLog.log.error("Error Reading File "+path+" in "+source.getAbsolutePath(),e);
+                return null;
+            }
+        }else return null;
+
+    }
+    public static boolean findFiles(File source, String base, Function<Path, Boolean> preprocessor, BiFunction<Path, Path, Boolean> processor,
+                                    boolean defaultUnfoundRoot, boolean visitAllFiles)
+    {
+        FileSystem fs = null;
+        boolean success = true;
+
+        try
+        {
+            Path root = null;
+
+            if (source.isFile())
+            {
+                try
+                {
+                    fs = FileSystems.newFileSystem(source.toPath(), (ClassLoader)null);
+                    root = fs.getPath("/" + base);
+                }
+                catch (IOException e)
+                {
+                    FMLLog.log.error("Error loading FileSystem from jar: ", e);
+                    return false;
+                }
+            }
+            else if (source.isDirectory())
+            {
+                root = source.toPath().resolve(base);
+            }
+
+            if (root == null || !Files.exists(root))
+                return defaultUnfoundRoot;
+
+            if (preprocessor != null)
+            {
+                Boolean cont = preprocessor.apply(root);
+                if (cont == null || !cont.booleanValue())
+                    return false;
+            }
+
+            if (processor != null)
+            {
+                Iterator<Path> itr = null;
+                try
+                {
+                    itr = Files.walk(root).iterator();
+                }
+                catch (IOException e)
+                {
+                    FMLLog.log.error("Error iterating filesystem for: {}", source.getAbsolutePath(), e);
+                    return false;
+                }
+
+                while (itr != null && itr.hasNext())
+                {
+                    Boolean cont = processor.apply(root, itr.next());
+
+                    if (visitAllFiles)
+                    {
+                        success &= cont != null && cont;
+                    }
+                    else if (cont == null || !cont)
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            IOUtils.closeQuietly(fs);
+        }
+
+        return success;
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
@@ -22,6 +22,8 @@ package net.minecraftforge.fml.common.discovery;
 import java.io.File;
 import java.util.List;
 
+import com.cleanroommc.event.EarlyBus;
+import com.cleanroommc.event.FMLDiscoverModEvent;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.LoaderException;
 import net.minecraftforge.fml.common.ModClassLoader;
@@ -105,7 +107,7 @@ public class ModDiscoverer
                 FMLLog.log.warn("Identified a problem with the mod candidate {}, ignoring this source", candidate.getModContainer(), le);
             }
         }
-
+        EarlyBus.BUS.post(new FMLDiscoverModEvent(()->this,()->modList));
         return modList;
     }
 

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -94,7 +94,7 @@ public class CoreModManager {
         }
     }
 
-    private static class FMLPluginWrapper implements ITweaker {
+    public static class FMLPluginWrapper implements ITweaker {
         public final String name;
         public final IFMLLoadingPlugin coreModInstance;
         public final List<String> predepends;

--- a/src/main/java/net/minecraftforge/fml/relauncher/IEarlyBusSubscribePlugin.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/IEarlyBusSubscribePlugin.java
@@ -1,0 +1,11 @@
+package net.minecraftforge.fml.relauncher;
+
+
+import com.google.common.eventbus.EventBus;
+
+/**
+ * A service for common mod to subscribe {@link com.cleanroommc.event.EarlyBus#BUS}
+ * **/
+public interface IEarlyBusSubscribePlugin {
+    void addToBus(EventBus bus);
+}

--- a/src/main/java/net/minecraftforge/fml/relauncher/MixinBooterPlugin.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/MixinBooterPlugin.java
@@ -1,6 +1,8 @@
 package net.minecraftforge.fml.relauncher;
 
 import com.cleanroommc.bouncepad.Bouncepad;
+import com.cleanroommc.event.EarlyBus;
+import com.cleanroommc.event.MixinBootEvent;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.common.ForgeVersion;
 import org.apache.logging.log4j.LogManager;
@@ -10,13 +12,11 @@ import org.spongepowered.asm.mixin.Mixins;
 import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
 import org.spongepowered.asm.mixin.transformer.ext.Extensions;
 import org.spongepowered.asm.mixin.transformer.ext.IExtension;
+import zone.rong.mixinbooter.IEarlyMixinLoader;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @IFMLLoadingPlugin.Name("MixinBooter")
 @IFMLLoadingPlugin.MCVersion(ForgeVersion.mcVersion)
@@ -50,35 +50,46 @@ public final class MixinBooterPlugin implements IFMLLoadingPlugin {
     @Override
     public void injectData(Map<String, Object> data) {
         Object coremodList = data.get("coremodList");
+        Class<?> clazz;
+        Method get;
+        Method should;
+        Method on;
+        Field fmlPluginWrapper$coreModInstance;
+        try{
+            clazz = Bouncepad.classLoader.loadClass("zone.rong.mixinbooter.IEarlyMixinLoader");
+            get = clazz.getDeclaredMethod("getMixinConfigs");
+            should = clazz.getDeclaredMethod("shouldMixinConfigQueue", String.class);
+            on = clazz.getDeclaredMethod("onMixinConfigQueued", String.class);
+        } catch (ClassNotFoundException|NoSuchMethodException e) {
+            throw new RuntimeException("can not launch mixinbooter",e);
+        }
+        List<Object> earlyMixinLoaders=new LinkedList<>();
         if (coremodList instanceof List) {
-            Field fmlPluginWrapper$coreModInstance = null;
-            for (Object coremod : (List) coremodList) {
+            for (CoreModManager.FMLPluginWrapper coremod : (List<CoreModManager.FMLPluginWrapper>) coremodList) {
                 try {
-                    if (fmlPluginWrapper$coreModInstance == null) {
-                        fmlPluginWrapper$coreModInstance = coremod.getClass().getField("coreModInstance");
-                        fmlPluginWrapper$coreModInstance.setAccessible(true);
-                    }
-                    Object theMod = fmlPluginWrapper$coreModInstance.get(coremod);
-                    Class<?> clazz = Bouncepad.classLoader.loadClass("zone.rong.mixinbooter.IEarlyMixinLoader");
-                    Method get = clazz.getDeclaredMethod("getMixinConfigs");
-                    Method should = clazz.getDeclaredMethod("shouldMixinConfigQueue", String.class);
-                    Method on = clazz.getDeclaredMethod("onMixinConfigQueued", String.class);
-                    if (clazz.isInstance(theMod)) {
-                        Object loader = clazz.cast(theMod);
-                        LOGGER.info("Grabbing {} for its mixins.", loader.getClass());
-                        for (String mixinConfig : (List<String>)get.invoke(loader)) {
-                            if ((Boolean) should.invoke(loader, mixinConfig)) {
-                                LOGGER.info("Adding {} mixin configuration.", mixinConfig);
-                                Mixins.addConfiguration(mixinConfig);
-                                on.invoke(loader, mixinConfig);
-                            }
-                        }
-                    } else if ("org.spongepowered.mod.SpongeCoremod".equals(theMod.getClass().getName())) {
+                    if (clazz.isInstance(coremod.coreModInstance)) {
+                        earlyMixinLoaders.add(clazz.cast(coremod.coreModInstance));
+                    } else if ("org.spongepowered.mod.SpongeCoremod".equals(coremod.coreModInstance.getClass().getName())) {
                         Launch.classLoader.registerTransformer("zone.rong.mixinbooter.fix.spongeforge.SpongeForgeFixer");
                     }
                 } catch (Throwable t) {
                     LOGGER.error("Unexpected error", t);
                 }
+            }
+        }
+        EarlyBus.BUS.post(new MixinBootEvent.Early(earlyMixinLoaders));
+        for (Object loader:earlyMixinLoaders){
+            try {
+                LOGGER.info("Grabbing {} for its mixins.", loader.getClass());
+                for (String mixinConfig : (List<String>) get.invoke(loader)) {
+                    if ((Boolean) should.invoke(loader, mixinConfig)) {
+                        LOGGER.info("Adding {} mixin configuration.", mixinConfig);
+                        Mixins.addConfiguration(mixinConfig);
+                        on.invoke(loader, mixinConfig);
+                    }
+                }
+            }catch (Throwable throwable){
+                LOGGER.error("Unexpected error", throwable);
             }
         }
     }


### PR DESCRIPTION
The early event bus and two events.
FMLDiscoverModEvent - enable modder add or remove ModContainer or do something before mod loaded but later than discovered.
MixinBootEvent - register the mixin loader (or block) by themselves.