### PR TITLE
Feature: Dispatch workflow event

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -55,7 +55,7 @@ jobs:
           if-no-files-found: error
 
       - uses: actions/github-script@v6
-        needs: upload-job
+        if: success()
         with:
           github-token: ${{ secrets.CLEANROOMMC_DISPATCH_TOKEN }} # require PAT :shrug:
           script: |

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -47,7 +47,22 @@ jobs:
           path: projects/cleanroom/build/libs/*-universal.jar
 
       - name: Upload Forge Installer
+        id: upload-job
         uses: actions/upload-artifact@v3.1.2
         with:
           name: installer
           path: projects/cleanroom/build/libs/*-installer.jar
+          if-no-files-found: error
+
+      - uses: actions/github-script@v6
+        needs: upload-job
+        with:
+          github-token: ${{ secrets.CLEANROOMMC_DISPATCH_TOKEN }} # require PAT :shrug:
+          script: |
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: 'CleanroomMC',
+              repo: 'CleanroomMMC',
+              event_type: 'cleanroom_upload_artifact',
+              client_payload: {"commit_hash": "${{ github.sha }}", "run_job_id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
+            })
+            console.log(result);

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -63,6 +63,6 @@ jobs:
               owner: 'CleanroomMC',
               repo: 'CleanroomMMC',
               event_type: 'cleanroom_upload_artifact',
-              client_payload: {"commit_hash": "${{ github.sha }}", "run_job_id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
+              client_payload: {"commit_hash": "${{ github.sha }}", "run_job_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
             })
             console.log(result);


### PR DESCRIPTION
Simple dispatch via github script plugin. Main usage to send event to other repo for purpose of creating MMC-variant instance pack.

Secret: `CLEANROOMMC_DISPATCH_TOKEN`

P/s: Idk if the PAT token part is required or not :stare: