### PR TITLE
Make Ender Dragon's XP drop fire LivingExperienceDropEvent for each "batch" of XP

### DIFF
--- a/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
@@ -443,18 +443,7 @@
          }
  
          boolean flag = this.field_70170_p.func_82736_K().func_82766_b("doMobLoot");
-@@ -741,7 +633,9 @@
-         {
-             if (this.field_70995_bG > 150 && this.field_70995_bG % 5 == 0 && flag)
-             {
--                this.func_184668_a(MathHelper.func_76141_d((float)i * 0.08F));
-+                int b = MathHelper.func_76141_d((float)i * 0.08F);
-+                b = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, b);
-+                if(b>0) this.func_184668_a(b);
-             }
- 
-             if (this.field_70995_bG == 1)
-@@ -750,7 +644,7 @@
+@@ -750,7 +642,7 @@
              }
          }
  
@@ -463,18 +452,16 @@
          this.field_70177_z += 20.0F;
          this.field_70761_aq = this.field_70177_z;
  
-@@ -758,7 +652,9 @@
-         {
-             if (flag)
-             {
--                this.func_184668_a(MathHelper.func_76141_d((float)i * 0.2F));
-+                int b = MathHelper.func_76141_d((float)i * 0.2F);
-+                b = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, b);
-+                if(b>0) this.func_184668_a(b);
-             }
+@@ -772,6 +664,8 @@
  
-             if (this.field_184676_bI != null)
-@@ -792,21 +688,21 @@
+     private void func_184668_a(int p_184668_1_)
+     {
++        p_184668_1_ = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, p_184668_1_);
++        if(p_184668_1_>0)
+         while (p_184668_1_ > 0)
+         {
+             int i = EntityXPOrb.func_70527_a(p_184668_1_);
+@@ -792,21 +686,21 @@
  
                  if (i < 12)
                  {
@@ -502,7 +489,7 @@
                  }
  
                  int j1 = Math.max(this.field_70170_p.func_181545_F() + 10, this.field_70170_p.func_175672_r(new BlockPos(l, 0, i1)).func_177956_o() + j);
-@@ -969,7 +865,7 @@
+@@ -969,7 +863,7 @@
          }
          else
          {
@@ -511,7 +498,7 @@
  
              if (p_184666_3_ != null)
              {
-@@ -1008,14 +904,12 @@
+@@ -1008,14 +902,12 @@
          EntityLiving.func_189752_a(p_189755_0_, EntityDragon.class);
      }
  
@@ -526,7 +513,7 @@
      public void func_70037_a(NBTTagCompound p_70037_1_)
      {
          super.func_70037_a(p_70037_1_);
-@@ -1026,55 +920,46 @@
+@@ -1026,55 +918,46 @@
          }
      }
  
@@ -582,7 +569,7 @@
      protected ResourceLocation func_184647_J()
      {
          return LootTableList.field_191189_ay;
-@@ -1087,24 +972,27 @@
+@@ -1087,24 +970,27 @@
          PhaseList <? extends IPhase > phaselist = iphase.func_188652_i();
          double d0;
  
@@ -623,7 +610,7 @@
  
          return (float)d0;
      }
-@@ -1115,28 +1003,31 @@
+@@ -1115,28 +1001,31 @@
          PhaseList <? extends IPhase > phaselist = iphase.func_188652_i();
          Vec3d vec3d;
  
@@ -673,7 +660,7 @@
          }
  
          return vec3d;
-@@ -1152,7 +1043,7 @@
+@@ -1152,7 +1041,7 @@
          }
          else
          {
@@ -682,7 +669,7 @@
          }
  
          if (p_184672_1_ == this.field_70992_bH)
-@@ -1163,12 +1054,11 @@
+@@ -1163,12 +1052,11 @@
          this.field_184677_bJ.func_188756_a().func_188655_a(p_184672_1_, p_184672_2_, p_184672_3_, entityplayer);
      }
  
@@ -696,7 +683,7 @@
          }
  
          super.func_184206_a(p_184206_1_);
-@@ -1185,18 +1075,15 @@
+@@ -1185,18 +1073,15 @@
          return this.field_184676_bI;
      }
  

--- a/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
@@ -443,7 +443,18 @@
          }
  
          boolean flag = this.field_70170_p.func_82736_K().func_82766_b("doMobLoot");
-@@ -750,7 +642,7 @@
+@@ -741,7 +633,9 @@
+         {
+             if (this.field_70995_bG > 150 && this.field_70995_bG % 5 == 0 && flag)
+             {
+-                this.func_184668_a(MathHelper.func_76141_d((float)i * 0.08F));
++                int b = MathHelper.func_76141_d((float)i * 0.08F);
++                b = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, b);
++                if(b>0) this.func_184668_a(b);
+             }
+ 
+             if (this.field_70995_bG == 1)
+@@ -750,7 +644,7 @@
              }
          }
  
@@ -452,7 +463,18 @@
          this.field_70177_z += 20.0F;
          this.field_70761_aq = this.field_70177_z;
  
-@@ -792,21 +684,21 @@
+@@ -758,7 +652,9 @@
+         {
+             if (flag)
+             {
+-                this.func_184668_a(MathHelper.func_76141_d((float)i * 0.2F));
++                int b = MathHelper.func_76141_d((float)i * 0.2F);
++                b = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, b);
++                if(b>0) this.func_184668_a(b);
+             }
+ 
+             if (this.field_184676_bI != null)
+@@ -792,21 +688,21 @@
  
                  if (i < 12)
                  {
@@ -480,7 +502,7 @@
                  }
  
                  int j1 = Math.max(this.field_70170_p.func_181545_F() + 10, this.field_70170_p.func_175672_r(new BlockPos(l, 0, i1)).func_177956_o() + j);
-@@ -969,7 +861,7 @@
+@@ -969,7 +865,7 @@
          }
          else
          {
@@ -489,7 +511,7 @@
  
              if (p_184666_3_ != null)
              {
-@@ -1008,14 +900,12 @@
+@@ -1008,14 +904,12 @@
          EntityLiving.func_189752_a(p_189755_0_, EntityDragon.class);
      }
  
@@ -504,7 +526,7 @@
      public void func_70037_a(NBTTagCompound p_70037_1_)
      {
          super.func_70037_a(p_70037_1_);
-@@ -1026,55 +916,46 @@
+@@ -1026,55 +920,46 @@
          }
      }
  
@@ -560,7 +582,7 @@
      protected ResourceLocation func_184647_J()
      {
          return LootTableList.field_191189_ay;
-@@ -1087,24 +968,27 @@
+@@ -1087,24 +972,27 @@
          PhaseList <? extends IPhase > phaselist = iphase.func_188652_i();
          double d0;
  
@@ -601,7 +623,7 @@
  
          return (float)d0;
      }
-@@ -1115,28 +999,31 @@
+@@ -1115,28 +1003,31 @@
          PhaseList <? extends IPhase > phaselist = iphase.func_188652_i();
          Vec3d vec3d;
  
@@ -651,7 +673,7 @@
          }
  
          return vec3d;
-@@ -1152,7 +1039,7 @@
+@@ -1152,7 +1043,7 @@
          }
          else
          {
@@ -660,7 +682,7 @@
          }
  
          if (p_184672_1_ == this.field_70992_bH)
-@@ -1163,12 +1050,11 @@
+@@ -1163,12 +1054,11 @@
          this.field_184677_bJ.func_188756_a().func_188655_a(p_184672_1_, p_184672_2_, p_184672_3_, entityplayer);
      }
  
@@ -674,7 +696,7 @@
          }
  
          super.func_184206_a(p_184206_1_);
-@@ -1185,18 +1071,15 @@
+@@ -1185,18 +1075,15 @@
          return this.field_184676_bI;
      }
  

--- a/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
@@ -457,7 +457,7 @@
      private void func_184668_a(int p_184668_1_)
      {
 +        p_184668_1_ = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, p_184668_1_);
-+        if(p_184668_1_>0)
++         
          while (p_184668_1_ > 0)
          {
              int i = EntityXPOrb.func_70527_a(p_184668_1_);


### PR DESCRIPTION
>this might not be as flexible as people want, but maybe just go for simple: just fire the event once for each "batch" of XP it spawns? the value is known for each batch in this case

Fix https://github.com/MinecraftForge/MinecraftForge/issues/4910  ?