### PR TITLE
Cache the Fluid owner and return it correctly.

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1485,7 +1485,10 @@ public class ForgeHooks
                 if (fluid == null || fluid == FluidRegistry.WATER || fluid == FluidRegistry.LAVA || fluid.getName().equals("milk"))
                 {
                     return "minecraft";
-                }else return "forge";//TODO : could we find the source of the fluid?
+                }else {
+                    modId = FluidRegistry.getOwner(fluid);
+                    return modId == null ? "unknown" : modId;
+                }
             }
         }
         return modId;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -144,7 +144,14 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.IFluidBlock;
+import net.minecraftforge.fluids.UniversalBucket;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.LoaderState;
@@ -154,6 +161,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher;
 import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.ConnectionType;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.registries.DataSerializerEntry;
 import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.GameData;
@@ -1470,6 +1478,14 @@ public class ForgeHooks
                 {
                     return resourceLocation.getNamespace();
                 }
+            }
+        }else if ("forge".equals(modId)){
+            if (item instanceof UniversalBucket universalBucket){
+                Fluid fluid = universalBucket.getFluid(itemStack).getFluid();
+                if (fluid == null || fluid == FluidRegistry.WATER || fluid == FluidRegistry.LAVA || fluid.getName().equals("milk"))
+                {
+                    return "minecraft";
+                }else return "forge";//TODO : could we find the source of the fluid?
             }
         }
         return modId;

--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -47,6 +47,7 @@ import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.registries.IRegistryDelegate;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -65,6 +66,7 @@ public abstract class FluidRegistry
     static BiMap<String,Fluid> masterFluidReference = HashBiMap.create();
     static BiMap<String,String> defaultFluidName = HashBiMap.create();
     static Map<Fluid,FluidDelegate> delegates = Maps.newHashMap();
+    static Map<Fluid,String> fluidOwner = Maps.newHashMap(); // Fluid - modid
 
     static boolean universalBucketEnabled = false;
     static Set<String> bucketFluids = Sets.newHashSet();
@@ -165,6 +167,7 @@ public abstract class FluidRegistry
             return false;
         }
         fluids.put(fluid.getName(), fluid);
+        fluidOwner.put(fluid, Loader.instance().activeModContainer() == null ? null : Loader.instance().activeModContainer().getModId());
         maxID++;
         fluidIDs.put(fluid, maxID);
         fluidNames.put(maxID, fluid.getName());
@@ -450,6 +453,11 @@ public abstract class FluidRegistry
     static IRegistryDelegate<Fluid> makeDelegate(Fluid fl)
     {
         return delegates.get(fl);
+    }
+
+    @Nullable
+    public static String getOwner(@Nonnull Fluid fluid){
+        return fluidOwner.get(fluid);
     }
 
 


### PR DESCRIPTION
The name of the `fluid` does not enforce `ResourceLocation`, and `FluidRegistry` also defaults to a name which is not a real `ResourceLocation` (handle the case of duplicate names). Many mods also do not use `String of ResourceLocation`, which means that it is impossible to obtain the correct owner.