### PR TITLE
Rewrite `<init>` of ResourceLocation and add `ResourceLocationInitEvent`

### DIFF
--- a/patches/minecraft/net/minecraft/util/ResourceLocation.java.patch
+++ b/patches/minecraft/net/minecraft/util/ResourceLocation.java.patch
@@ -1,0 +1,33 @@
+--- before/net/minecraft/util/ResourceLocation.java
++++ after/net/minecraft/util/ResourceLocation.java
+@@ -9,6 +9,8 @@
+ import com.google.gson.JsonSerializer;
+ import java.lang.reflect.Type;
+ import java.util.Locale;
++import java.util.Objects;
++
+ import org.apache.commons.lang3.Validate;
+ 
+ public class ResourceLocation implements Comparable<ResourceLocation>
+@@ -18,9 +20,7 @@
+ 
+     protected ResourceLocation(int p_i45928_1_, String... p_i45928_2_)
+     {
+-        this.field_110626_a = org.apache.commons.lang3.StringUtils.isEmpty(p_i45928_2_[0]) ? "minecraft" : p_i45928_2_[0].toLowerCase(Locale.ROOT);
+-        this.field_110625_b = p_i45928_2_[1].toLowerCase(Locale.ROOT);
+-        Validate.notNull(this.field_110625_b);
++        this(org.apache.commons.lang3.StringUtils.isEmpty(p_i45928_2_[0]) ? "minecraft" : p_i45928_2_[0].toLowerCase(Locale.ROOT), Objects.requireNonNull(p_i45928_2_[1].toLowerCase(Locale.ROOT), "the path of ResourceLocation is non-null!"));
+     }
+ 
+     public ResourceLocation(String p_i1293_1_)
+@@ -30,7 +30,9 @@
+ 
+     public ResourceLocation(String p_i1292_1_, String p_i1292_2_)
+     {
+-        this(0, p_i1292_1_, p_i1292_2_);
++        String[] s = net.minecraftforge.common.ForgeHooks.onResourceLocationInit(p_i1292_1_, p_i1292_2_);
++        this.field_110626_a = s[0];
++        this.field_110625_b = s[1];
+     }
+ 
+     public static String[] func_177516_a(String p_177516_0_)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -142,6 +142,7 @@ import net.minecraftforge.event.entity.player.CriticalHitEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
+import net.minecraftforge.event.utils.ResourceLocationInitEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
 import net.minecraftforge.fluids.IFluidBlock;
@@ -1486,6 +1487,13 @@ public class ForgeHooks
         }
         return false;
     }
+
+    public static String[] onResourceLocationInit(String namespace, String path){
+        ResourceLocationInitEvent evt = new ResourceLocationInitEvent(namespace, path);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return new String[]{evt.getNamespace(), evt.getPath()};
+    }
+
 
     private static final Map<DataSerializer<?>, DataSerializerEntry> serializerEntries = GameData.getSerializerMap();
     private static final ForgeRegistry<DataSerializerEntry> serializerRegistry = (ForgeRegistry<DataSerializerEntry>) ForgeRegistries.DATA_SERIALIZERS;

--- a/src/main/java/net/minecraftforge/event/utils/ResourceLocationInitEvent.java
+++ b/src/main/java/net/minecraftforge/event/utils/ResourceLocationInitEvent.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.event.utils;
+
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * ResourceLocationInitEvent is fired whenever a {@link net.minecraft.util.ResourceLocation} is to be init.
+ * <br>
+ * This event is not {@link net.minecraftforge.fml.common.eventhandler.Cancelable}. <br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.<br>
+ **/
+public class ResourceLocationInitEvent extends Event {
+    private String namespace;
+    private String path;
+    public ResourceLocationInitEvent(String namespace, String path){
+        this.namespace = namespace;
+        this.path = path;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}


### PR DESCRIPTION
### result

```java
    protected ResourceLocation(int unused, String... resourceName)
    {
        this(org.apache.commons.lang3.StringUtils.isEmpty(resourceName[0]) ? "minecraft" : resourceName[0].toLowerCase(Locale.ROOT), Objects.requireNonNull(resourceName[1].toLowerCase(Locale.ROOT), "the path of ResourceLocation is non-null!"));
    }

    public ResourceLocation(String resourceName)
    {
        this(0, splitObjectName(resourceName));
    }

    public ResourceLocation(String namespaceIn, String pathIn)
    {
        String[] s = net.minecraftforge.common.ForgeHooks.onResourceLocationInit(namespaceIn, pathIn);
        this.namespace = s[0];
        this.path = s[1];
    }
```
### Event

`ResourceLocationInitEvent`, used for redirection or ...