### PR TITLE
`CreativeTabEvent`s and make the CreativeTabBackgroundImage could be set as `ResourceLocation`

### DIFF
--- a/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
+++ b/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
@@ -135,7 +135,7 @@
      private final int field_78033_n;
      private final String field_78034_o;
 -    private String field_78043_p = "items.png";
-+    private net.minecraft.util.ResourceLocation field_78043_p = makeVanillaTextureLocation("items.png");
++    private net.minecraft.util.ResourceLocation backgroundTextureLocation = makeVanillaTextureLocation("items.png");
      private boolean field_78042_q = true;
      private boolean field_78041_r = true;
      private EnumEnchantmentType[] field_111230_s = new EnumEnchantmentType[0];
@@ -170,7 +170,7 @@
 +    }
 +
 +    public CreativeTabs setBackgroundImageName(net.minecraft.util.ResourceLocation texture){
-+        this.field_78043_p = texture;
++        this.backgroundTextureLocation = texture;
 +        return this;
 +    }
 +
@@ -192,8 +192,8 @@
 -    {
 -        this.field_78043_p = p_78025_1_;
 -        return this;
-+        if ("minecraft".equals(field_78043_p.func_110624_b()) && field_78043_p.func_110623_a().startsWith("textures/gui/container/creative_inventory/tab_")){
-+            return field_78043_p.func_110623_a().substring("textures/gui/container/creative_inventory/tab_".length());
++        if ("minecraft".equals(backgroundTextureLocation.func_110624_b()) && backgroundTextureLocation.func_110623_a().startsWith("textures/gui/container/creative_inventory/tab_")){
++            return backgroundTextureLocation.func_110623_a().substring("textures/gui/container/creative_inventory/tab_".length());
 +        }
 +        else return "items.png";
      }
@@ -272,7 +272,7 @@
 +    @SideOnly(Side.CLIENT)
 +    public net.minecraft.util.ResourceLocation getBackgroundImage()
 +    {
-+        return field_78043_p;
++        return backgroundTextureLocation;
 +    }
 +
 +    public int getLabelColor()

--- a/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
+++ b/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
@@ -130,7 +130,14 @@
          public ItemStack func_78016_d()
          {
              return new ItemStack(Item.func_150898_a(Blocks.field_150486_ae));
-@@ -163,8 +131,22 @@
+@@ -157,14 +125,28 @@
+     }).func_78025_a("inventory.png").func_78022_j().func_78014_h();
+     private final int field_78033_n;
+     private final String field_78034_o;
+-    private String field_78043_p = "items.png";
++    private net.minecraft.util.ResourceLocation field_78043_p = makeVanillaTextureLocation("items.png");
+     private boolean field_78042_q = true;
+     private boolean field_78041_r = true;
      private EnumEnchantmentType[] field_111230_s = new EnumEnchantmentType[0];
      private ItemStack field_151245_t;
  
@@ -153,33 +160,46 @@
          this.field_78033_n = p_i1853_1_;
          this.field_78034_o = p_i1853_2_;
          this.field_151245_t = ItemStack.field_190927_a;
-@@ -177,6 +159,12 @@
+@@ -177,6 +159,16 @@
          return this.field_78033_n;
      }
  
 +    public CreativeTabs func_78025_a(String p_78025_1_)
 +    {
-+        this.field_78043_p = p_78025_1_;
++        return this.setBackgroundImageName(makeVanillaTextureLocation(p_78025_1_));
++    }
++
++    public CreativeTabs setBackgroundImageName(net.minecraft.util.ResourceLocation texture){
++        this.field_78043_p = texture;
 +        return this;
 +    }
 +
      @SideOnly(Side.CLIENT)
      public String func_78013_b()
      {
-@@ -209,12 +197,6 @@
-         return this.field_78043_p;
-     }
+@@ -203,16 +195,14 @@
+     @SideOnly(Side.CLIENT)
+     public abstract ItemStack func_78016_d();
  
++    @Deprecated //Forge : Modders call getBackgroundImage()Lnet/minecraft/util/ResourceLocation; instead.
+     @SideOnly(Side.CLIENT)
+     public String func_78015_f()
+     {
+-        return this.field_78043_p;
+-    }
+-
 -    public CreativeTabs func_78025_a(String p_78025_1_)
 -    {
 -        this.field_78043_p = p_78025_1_;
 -        return this;
--    }
--
++        if ("minecraft".equals(field_78043_p.func_110624_b()) && field_78043_p.func_110623_a().startsWith("textures/gui/container/creative_inventory/tab_")){
++            return field_78043_p.func_110623_a().substring("textures/gui/container/creative_inventory/tab_".length());
++        }
++        else return "items.png";
+     }
+ 
      @SideOnly(Side.CLIENT)
-     public boolean func_78019_g()
-     {
-@@ -242,12 +224,20 @@
+@@ -242,12 +232,20 @@
      @SideOnly(Side.CLIENT)
      public int func_78020_k()
      {
@@ -200,18 +220,26 @@
          return this.field_78033_n < 6;
      }
  
-@@ -291,5 +281,51 @@
-         {
-             item.func_150895_a(this, p_78018_1_);
-         }
+@@ -287,9 +285,61 @@
+     @SideOnly(Side.CLIENT)
+     public void func_78018_a(NonNullList<ItemStack> p_78018_1_)
+     {
+-        for (Item item : Item.field_150901_e)
++        if (!net.minecraftforge.common.ForgeHooks.preCreativeTabsSubItems(this, p_78018_1_)) {
++            for (Item item : Item.field_150901_e) {
++                item.func_150895_a(this, p_78018_1_);
++            }
++            net.minecraftforge.common.ForgeHooks.postCreativeTabsSubItems(this, p_78018_1_);
++        }
 +    }
 +
 +    public int getTabPage()
 +    {
 +        if (field_78033_n > 11)
-+        {
+         {
+-            item.func_150895_a(this, p_78018_1_);
 +            return ((field_78033_n - 12) / 10) + 1;
-+        }
+         }
 +        return 0;
 +    }
 +
@@ -244,11 +272,15 @@
 +    @SideOnly(Side.CLIENT)
 +    public net.minecraft.util.ResourceLocation getBackgroundImage()
 +    {
-+        return new net.minecraft.util.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.func_78015_f());
++        return field_78043_p;
 +    }
 +
 +    public int getLabelColor()
 +    {
 +        return 4210752;
++    }
++
++    public static net.minecraft.util.ResourceLocation makeVanillaTextureLocation(String texture){
++        return new net.minecraft.util.ResourceLocation("minecraft","textures/gui/container/creative_inventory/tab_"+texture);
      }
  }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -51,6 +51,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
@@ -142,6 +143,7 @@ import net.minecraftforge.event.entity.player.CriticalHitEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
+import net.minecraftforge.event.items.CreativeTabEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
 import net.minecraftforge.fluids.IFluidBlock;
@@ -1511,5 +1513,13 @@ public class ForgeHooks
             if (entry != null) id = serializerRegistry.getID(entry);
         }
         return id;
+    }
+
+    public static boolean preCreativeTabsSubItems(CreativeTabs tabIn, NonNullList<ItemStack> subItems){
+        return MinecraftForge.EVENT_BUS.post(new CreativeTabEvent.PreSubItems(tabIn, subItems));
+    }
+
+    public static void postCreativeTabsSubItems(CreativeTabs tabIn, NonNullList<ItemStack> subItems){
+        MinecraftForge.EVENT_BUS.post(new CreativeTabEvent.PostSubItems(tabIn, subItems));
     }
 }

--- a/src/main/java/net/minecraftforge/event/items/CreativeTabEvent.java
+++ b/src/main/java/net/minecraftforge/event/items/CreativeTabEvent.java
@@ -1,0 +1,59 @@
+package net.minecraftforge.event.items;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
+ **/
+public class CreativeTabEvent extends Event {
+    private final CreativeTabs tab;
+    public CreativeTabEvent(CreativeTabs tabIn){
+        this.tab = tabIn;
+    }
+
+    private static class SubItems extends CreativeTabEvent{
+        private NonNullList<ItemStack> subItems;
+
+        public SubItems(CreativeTabs tabIn, NonNullList<ItemStack> subItemsIn) {
+            super(tabIn);
+            this.subItems = subItemsIn;
+        }
+
+        public NonNullList<ItemStack> getSubItems() {
+            return subItems;
+        }
+
+        public void add(ItemStack stack){
+            subItems.add(stack);
+        }
+    }
+
+    /**
+     * This event is {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * **/
+    @Cancelable
+    public static class PreSubItems extends SubItems{
+        public PreSubItems(CreativeTabs tabIn, NonNullList<ItemStack> subItemsIn) {
+            super(tabIn, subItemsIn);
+        }
+    }
+
+    /**
+     * this event will not be fired if {@link PreSubItems} is canceled.
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * **/
+    public static class PostSubItems extends SubItems{
+        public PostSubItems(CreativeTabs tabIn, NonNullList<ItemStack> subItemsIn) {
+            super(tabIn, subItemsIn);
+        }
+    }
+}


### PR DESCRIPTION
CreativeTabSubItemsEvent is used for add items into tab.
`Item#getSubItems` cannot require ordering between items.
We also cannot add Item to the tab customly.