### PR TITLE
actually apply ASCII font when "Force Unicode" is off

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/Locale.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/Locale.java.patch
@@ -20,16 +20,34 @@
                  }
              }
          }
-@@ -72,7 +73,7 @@
-         }
+@@ -53,26 +54,6 @@
  
-         float f = (float)i / (float)j;
+     private void func_135024_b()
+     {
+-        this.field_135029_d = false;
+-        int i = 0;
+-        int j = 0;
+-
+-        for (String s : this.field_135032_a.values())
+-        {
+-            int k = s.length();
+-            j += k;
+-
+-            for (int l = 0; l < k; ++l)
+-            {
+-                if (s.charAt(l) >= 256)
+-                {
+-                    ++i;
+-                }
+-            }
+-        }
+-
+-        float f = (float)i / (float)j;
 -        this.field_135029_d = (double)f > 0.1;
-+        this.field_135029_d = (double)f > 0.1D;
      }
  
      private void func_135028_a(List<IResource> p_135028_1_) throws IOException
-@@ -94,11 +95,13 @@
+@@ -94,11 +75,13 @@
  
      private void func_135021_a(InputStream p_135021_1_) throws IOException
      {
@@ -44,7 +62,7 @@
  
                  if (astring != null && astring.length == 2)
                  {
-@@ -124,7 +127,7 @@
+@@ -124,7 +107,7 @@
          {
              return String.format(s, p_135023_2_);
          }


### PR DESCRIPTION
This PR:
- Allow users whose locale contains a certain amount of Non-ASCII fonts can actually get ASCII fonts when "forceUnicode" option is set to OFF. 

## Impl details
The idea is simple, just remove mojang's forced-enabled unicode check, so that user's option can actually takes effect. 

This is the same as what ForceASCIIFont does. ForceASCIIFont do so by injecting a `RETURN` to the front of the checking function to skip unicode check, while here I just remove its logic completely. 

ForceASCIIFont's apporach: https://github.com/ZekerZhayard/ForceASCIIFont/blob/0efd9d66f8a80666a28890779dd199270672ad82/src/main/java/io/github/zekerzhayard/forceasciifont/asm/ClassTransformer.java

## Testing
`zh_cn` and `ja_jp`  are all I know that will suffer from this problem, so I'm only testing them. 
I also tested `en_us`, to make sure this patch does not break anything. 
|Locale|forceUnicode: ON|forceUnicode: OFF|
|----|--|--|
|en_us|<img width="429" alt="屏幕截图 2024-03-19 220403" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/71d1d4db-8b26-4fec-bcc8-859699cdf8ef">|<img width="429" alt="屏幕截图 2024-03-19 220323" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/f003aba7-9b2c-45fb-a32c-0392689f0e58">|
|zh_cn|<img width="429" alt="屏幕截图 2024-03-19 220427" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/7c39d5be-9cec-41f3-846e-c3af53954c8d">|<img width="429" alt="屏幕截图 2024-03-19 220417" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/690a3feb-b29d-437e-a4fd-458f79e53a14">|
|ja_jp|<img width="429" alt="屏幕截图 2024-03-19 220442" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/1ceeab58-40e7-4e0f-9bff-5d146d751c12">|<img width="429" alt="屏幕截图 2024-03-19 220452" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/3ee87585-3fc1-46c4-bdb5-566029207709">|

