### PR TITLE
[MC-30646]Make the world closed, fix Hardcore LAN world/server leak

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiGameOver.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiGameOver.java.patch
@@ -1,0 +1,11 @@
+--- before/net/minecraft/client/gui/GuiGameOver.java
++++ after/net/minecraft/client/gui/GuiGameOver.java
+@@ -74,7 +74,7 @@
+ 
+                 if (this.field_146297_k.field_71441_e.func_72912_H().func_76093_s())
+                 {
+-                    this.field_146297_k.func_147108_a(new GuiMainMenu());
++                    func_73878_a(true, 0); // Forge : Fix MC-30646
+                 }
+                 else
+                 {


### PR DESCRIPTION
### Summary

Minecraft just display a new `GuiMain` without closing the old world.

### Relates 
Fix https://github.com/MinecraftForge/MinecraftForge/issues/5690
Fix https://bugs.mojang.com/browse/MC-30646

### Addition
Make the result be confirmed `yes`.
### Deletion
The `confirmClick` has display the new `GuiMain` so i delete `it`(in the `actionPerformed`).
```java
    public void confirmClicked(boolean result, int id)
    {
        if (result)
        {
            if (this.mc.world != null)
            {
                this.mc.world.sendQuittingDisconnectingPacket();
            }

            this.mc.loadWorld(null);
            this.mc.displayGuiScreen(new GuiMainMenu()); // here <--------
        }
```