### PR TITLE
Fixes MC-94054

### DIFF
--- a/patches/minecraft/net/minecraft/pathfinding/PathNavigateClimber.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/PathNavigateClimber.java.patch
@@ -1,0 +1,11 @@
+--- before/net/minecraft/pathfinding/PathNavigateClimber.java
++++ after/net/minecraft/pathfinding/PathNavigateClimber.java
+@@ -57,7 +57,7 @@
+         {
+             if (this.field_179696_f != null)
+             {
+-                double d0 = (double)(this.field_75515_a.field_70130_N * this.field_75515_a.field_70130_N);
++                double d0 = Math.max((this.field_75515_a.field_70130_N * this.field_75515_a.field_70130_N), 1.0D);
+ 
+                 if (!(this.field_75515_a.func_174831_c(this.field_179696_f) < d0)
+                         && (


### PR DESCRIPTION
Fixes [MC-94054](https://bugs.mojang.com/browse/MC-94054), which made living entities that use PathNavigateClimber while having their width smaller than 1.0 keep spinning randomly.