### PR TITLE
Patch implementation of NonConflictKeys

### DIFF
--- a/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
@@ -15,16 +15,21 @@
      private final String field_74515_c;
      private final int field_151472_e;
      private final String field_151471_f;
-@@ -29,7 +29,7 @@
+@@ -29,12 +29,7 @@
      {
          if (p_74507_0_ != 0)
          {
 -            KeyBinding keybinding = field_74514_b.func_76041_a(p_74507_0_);
-+            KeyBinding keybinding = field_74514_b.lookupActive(p_74507_0_);
+-
+-            if (keybinding != null)
+-            {
+-                ++keybinding.field_151474_i;
+-            }
++            field_74514_b.lookupActives(p_74507_0_).forEach($ -> ++$.field_151474_i);
+         }
+     }
  
-             if (keybinding != null)
-             {
-@@ -42,7 +42,7 @@
+@@ -42,7 +37,7 @@
      {
          if (p_74510_0_ != 0)
          {
@@ -33,7 +38,7 @@
  
              if (keybinding != null)
              {
-@@ -59,8 +59,9 @@
+@@ -59,8 +54,9 @@
              {
                  func_74510_a(keybinding.field_74512_d, keybinding.field_74512_d < 256 && Keyboard.isKeyDown(keybinding.field_74512_d));
              }
@@ -44,7 +49,7 @@
              }
          }
      }
-@@ -75,11 +76,11 @@
+@@ -75,11 +71,11 @@
  
      public static void func_74508_b()
      {
@@ -58,7 +63,7 @@
          }
      }
  
-@@ -95,13 +96,13 @@
+@@ -95,13 +91,13 @@
          this.field_151472_e = p_i45001_2_;
          this.field_151471_f = p_i45001_3_;
          field_74516_a.put(p_i45001_1_, this);
@@ -74,7 +79,7 @@
      }
  
      public String func_151466_e()
-@@ -150,25 +151,166 @@
+@@ -150,25 +146,166 @@
  
      public int compareTo(KeyBinding p_compareTo_1_)
      {

--- a/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
@@ -22,7 +22,6 @@ package net.minecraftforge.client.settings;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.util.IntHashMap;
 
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -35,21 +34,6 @@ public class KeyBindingMap
         {
             map.put(modifier, new IntHashMap<Collection<KeyBinding>>());
         }
-    }
-
-    @Nullable
-    public KeyBinding lookupActive(int keyCode)
-    {
-        KeyModifier activeModifier = KeyModifier.getActiveModifier();
-        if (!activeModifier.matches(keyCode))
-        {
-            KeyBinding binding = getBinding(keyCode, activeModifier);
-            if (binding != null)
-            {
-                return binding;
-            }
-        }
-        return getBinding(keyCode, KeyModifier.NONE);
     }
 
     public Set<KeyBinding> lookupActives(int keyCode)
@@ -65,24 +49,6 @@ public class KeyBindingMap
         }
         return getBindings(keyCode, KeyModifier.NONE);
     }
-
-    @Nullable
-    private KeyBinding getBinding(int keyCode, KeyModifier keyModifier)
-    {
-        Collection<KeyBinding> bindings = map.get(keyModifier).lookup(keyCode);
-        if (bindings != null)
-        {
-            for (KeyBinding binding : bindings)
-            {
-                if (binding.isActiveAndMatches(keyCode))
-                {
-                    return binding;
-                }
-            }
-        }
-        return null;
-    }
-
 
     private Set<KeyBinding> getBindings(int keyCode, KeyModifier keyModifier)
     {

--- a/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
@@ -22,6 +22,7 @@ package net.minecraftforge.client.settings;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.util.IntHashMap;
 
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -36,6 +37,22 @@ public class KeyBindingMap
         }
     }
 
+    @Nullable
+    @Deprecated // Cleanroom: Use lookupActives
+    public KeyBinding lookupActive(int keyCode)
+    {
+        KeyModifier activeModifier = KeyModifier.getActiveModifier();
+        if (!activeModifier.matches(keyCode))
+        {
+            KeyBinding binding = getBinding(keyCode, activeModifier);
+            if (binding != null)
+            {
+                return binding;
+            }
+        }
+        return getBinding(keyCode, KeyModifier.NONE);
+    }
+
     public Set<KeyBinding> lookupActives(int keyCode)
     {
         KeyModifier activeModifier = KeyModifier.getActiveModifier();
@@ -48,6 +65,23 @@ public class KeyBindingMap
             }
         }
         return getBindings(keyCode, KeyModifier.NONE);
+    }
+
+    @Nullable
+    private KeyBinding getBinding(int keyCode, KeyModifier keyModifier)
+    {
+        Collection<KeyBinding> bindings = map.get(keyModifier).lookup(keyCode);
+        if (bindings != null)
+        {
+            for (KeyBinding binding : bindings)
+            {
+                if (binding.isActiveAndMatches(keyCode))
+                {
+                    return binding;
+                }
+            }
+        }
+        return null;
     }
 
     private Set<KeyBinding> getBindings(int keyCode, KeyModifier keyModifier)

--- a/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
@@ -23,10 +23,8 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.util.IntHashMap;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class KeyBindingMap
 {
@@ -54,6 +52,20 @@ public class KeyBindingMap
         return getBinding(keyCode, KeyModifier.NONE);
     }
 
+    public Set<KeyBinding> lookupActives(int keyCode)
+    {
+        KeyModifier activeModifier = KeyModifier.getActiveModifier();
+        if (!activeModifier.matches(keyCode))
+        {
+            Set<KeyBinding> bindings = getBindings(keyCode, activeModifier);
+            if (!bindings.isEmpty())
+            {
+                return bindings;
+            }
+        }
+        return getBindings(keyCode, KeyModifier.NONE);
+    }
+
     @Nullable
     private KeyBinding getBinding(int keyCode, KeyModifier keyModifier)
     {
@@ -69,6 +81,17 @@ public class KeyBindingMap
             }
         }
         return null;
+    }
+
+
+    private Set<KeyBinding> getBindings(int keyCode, KeyModifier keyModifier)
+    {
+        Collection<KeyBinding> bindings = map.get(keyModifier).lookup(keyCode);
+        if (bindings == null)
+        {
+            return Collections.emptySet();
+        }
+        return bindings.stream().filter($ -> $.isActiveAndMatches(keyCode)).collect(Collectors.toSet());
     }
 
     public List<KeyBinding> lookupAll(int keyCode)


### PR DESCRIPTION
This allows multiple KeyBindings with the same bound key to be triggered when the bound key is pressed, actually what [NonConflictKeys](https://www.curseforge.com/minecraft/mc-mods/nonconflictkeys) did.