### PR TITLE
Fix ScrollingSpeed for Forge

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
@@ -196,7 +196,7 @@ public abstract class GuiScrollingList
         int scroll = Mouse.getEventDWheel();
         if (scroll != 0)
         {
-            this.scrollDistance += (float)((-1 * scroll / 120.0F) * this.slotHeight / 2);
+            this.scrollDistance += (float)((-1 * scroll) * this.slotHeight / 2);
         }
     }
 


### PR DESCRIPTION
Fix #66 for forge.
Remove `/120F` on `GuiScrollingList`, a open API for Forge and mods.