### PR TITLE
apply `GuiIngameForge` options only when running on client

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -425,20 +425,23 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
             values[i] = prop.getBoolean(true);
         }
 
-        GuiIngameForge.renderVignette       = values[0];
-        GuiIngameForge.renderHelmet         = values[1];
-        GuiIngameForge.renderPortal         = values[2];
-        GuiIngameForge.renderHotbar         = values[3];
-        GuiIngameForge.renderCrosshairs     = values[4];
-        GuiIngameForge.renderBossHealth     = values[5];
-        GuiIngameForge.renderHealth         = values[6];
-        GuiIngameForge.renderArmor          = values[7];
-        GuiIngameForge.renderFood           = values[8];
-        GuiIngameForge.renderHealthMount    = values[9];
-        GuiIngameForge.renderAir            = values[10];
-        GuiIngameForge.renderExperiance     = values[11];
-        GuiIngameForge.renderJumpBar        = values[12];
-        GuiIngameForge.renderObjective      = values[13];
+        if (FMLCommonHandler.instance().getSide().isClient()) {
+            //`GuiIngameForge` class is client-only
+            GuiIngameForge.renderVignette    = values[0];
+            GuiIngameForge.renderHelmet      = values[1];
+            GuiIngameForge.renderPortal      = values[2];
+            GuiIngameForge.renderHotbar      = values[3];
+            GuiIngameForge.renderCrosshairs  = values[4];
+            GuiIngameForge.renderBossHealth  = values[5];
+            GuiIngameForge.renderHealth      = values[6];
+            GuiIngameForge.renderArmor       = values[7];
+            GuiIngameForge.renderFood        = values[8];
+            GuiIngameForge.renderHealthMount = values[9];
+            GuiIngameForge.renderAir         = values[10];
+            GuiIngameForge.renderExperiance  = values[11];
+            GuiIngameForge.renderJumpBar     = values[12];
+            GuiIngameForge.renderObjective   = values[13];
+        }
 
         return order;
     }


### PR DESCRIPTION
This PR:
- adds a sanity check to prevent applying client-only options when running on server, (which will cause a `NoClassDefFoundError`)

## Testing
Testing is done by running `cleanroomServer` task from Gradle.

### before
<img width="566" alt="before" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/38f4ca0d-3284-4acb-82e6-0bc4d98f15f5">

### after
<img width="597" alt="after" src="https://github.com/CleanroomMC/Cleanroom/assets/47418975/0f8915d4-bbe4-4ea8-a158-e2dea9f66b96">
