### PR TITLE
Bump Gradle to 8.8

### DIFF
--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Set up JDK 22
-      uses: actions/setup-java@v3.10.0
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: '22'
         distribution: 'temurin'

--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    - name: Set up JDK 21
+    - name: Set up JDK 22
       uses: actions/setup-java@v3.10.0
       with:
-        java-version: '21'
+        java-version: '22'
         distribution: 'temurin'
 
     - name: Fix Gradle Permission

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -35,10 +35,10 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 22
         uses: actions/setup-java@v4.2.1
         with:
-          java-version: '21'
+          java-version: '22'
           distribution: 'temurin'
 
       - name: Get branch names.

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -17,10 +17,10 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 22
         uses: actions/setup-java@v4.2.1
         with:
-          java-version: '21'
+          java-version: '22'
           distribution: 'temurin'
 
       - name: Fix Gradle permission

--- a/.github/workflows/WindowsTest.yml
+++ b/.github/workflows/WindowsTest.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
-      - name: Set up JDK 21
+      - name: Set up JDK 22
         uses: actions/setup-java@v4.2.1
         with:
-          java-version: '21'
+          java-version: '22'
           distribution: 'semeru'
 
       - name: Setup Forge env

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This allows development with JDK 22. I updated the Github Actions workflows to use JDK 22.