### PR TITLE
Improve the "Duped mods" error message

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiDupesFound.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiDupesFound.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml.client;
 
+import net.minecraft.client.resources.I18n;
 import net.minecraftforge.fml.common.DuplicateModsFoundException;
 import net.minecraftforge.fml.common.ModContainer;
 
@@ -40,7 +41,7 @@ public class GuiDupesFound extends GuiErrorBase
     {
         this.drawDefaultBackground();
         int offset = Math.max(85 - dupes.dupes.size() * 10, 10);
-        this.drawCenteredString(this.fontRenderer, "Forge Mod Loader has found a problem with your minecraft installation", this.width / 2, offset, 0xFFFFFF);
+        this.drawCenteredString(this.fontRenderer, I18n.format("fml.messages.load.problem.found"), this.width / 2, offset, 0xFFFFFF);
         offset+=10;
         this.drawCenteredString(this.fontRenderer, "You have duplicate mods installed. Please remove duplicates to avoid conflicts.", this.width / 2, offset, 0xFFFFFF);
         offset+=10;

--- a/src/main/java/net/minecraftforge/fml/client/GuiDupesFound.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiDupesFound.java
@@ -42,7 +42,7 @@ public class GuiDupesFound extends GuiErrorBase
         int offset = Math.max(85 - dupes.dupes.size() * 10, 10);
         this.drawCenteredString(this.fontRenderer, "Forge Mod Loader has found a problem with your minecraft installation", this.width / 2, offset, 0xFFFFFF);
         offset+=10;
-        this.drawCenteredString(this.fontRenderer, "You have mod sources that are duplicate within your system", this.width / 2, offset, 0xFFFFFF);
+        this.drawCenteredString(this.fontRenderer, "You have duplicate mods installed. Please remove duplicates to avoid conflicts.", this.width / 2, offset, 0xFFFFFF);
         offset+=10;
         this.drawCenteredString(this.fontRenderer, "Mod Id : File name", this.width / 2, offset, 0xFFFFFF);
         offset+=5;

--- a/src/main/java/net/minecraftforge/fml/client/GuiSortingProblem.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiSortingProblem.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.fml.client;
 
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.resources.I18n;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.toposort.ModSortingException;
 import net.minecraftforge.fml.common.toposort.ModSortingException.SortingExceptionData;
@@ -43,7 +44,7 @@ public class GuiSortingProblem extends GuiScreen {
     {
         this.drawDefaultBackground();
         int offset = Math.max(85 - (failedList.getVisitedNodes().size() + 3) * 10, 10);
-        this.drawCenteredString(this.fontRenderer, "Forge Mod Loader has found a problem with your minecraft installation", this.width / 2, offset, 0xFFFFFF);
+        this.drawCenteredString(this.fontRenderer, I18n.format("fml.messages.load.problem.found"), this.width / 2, offset, 0xFFFFFF);
         offset+=10;
         this.drawCenteredString(this.fontRenderer, "A mod sorting cycle was detected and loading cannot continue", this.width / 2, offset, 0xFFFFFF);
         offset+=10;

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -207,6 +207,8 @@ fml.menu.modoptions=Mod Options...
 
 item.forge.bucketFilled.name=%s Bucket
 
+
+fml.messages.load.problem.found=Forge Mod Loader has found a problem with your minecraft installation
 fml.messages.mod.missing.dependencies=%s is missing mods it depends on.
 fml.messages.mod.missing.dependencies.fix=Include the following mods or remove %s.
 fml.messages.mod.missing.dependencies.compatibility=You must include the right dependencies for %s:


### PR DESCRIPTION
This slightly improves the error message for when there are duplicate mods.

- Removes the old message because it was worded a little weird.
- Adds a new message that also explains how to fix the error. 