### PR TITLE
Fix getPixelScaleFactor

### DIFF
--- a/src/main/java/org/lwjgl/input/Mouse.java
+++ b/src/main/java/org/lwjgl/input/Mouse.java
@@ -53,9 +53,9 @@ public class Mouse {
             ignoreNextMove--;
             return;
         }
-        /*float scale = Display.getPixelScaleFactor();
+        float scale = Display.getPixelScaleFactor();
         mouseX *= scale;
-        mouseY *= scale;*/
+        mouseY *= scale;
         dx += (int) mouseX - latestX;
         dy += Display.getHeight() - (int) mouseY - latestY;
         latestX = (int) mouseX;

--- a/src/main/java/org/lwjgl/opengl/Display.java
+++ b/src/main/java/org/lwjgl/opengl/Display.java
@@ -442,10 +442,20 @@ public class Display {
         if (!isCreated()) {
             return 1.0f;
         }
-        float[] xScale = new float[1];
-        float[] yScale = new float[1];
-        glfwGetWindowContentScale(getWindow(), xScale, yScale);
-        return Math.max(xScale[0], yScale[0]);
+        int[] windowWidth = new int[1];
+        int[] windowHeight = new int[1];
+        int[] framebufferWidth = new int[1];
+        int[] framebufferHeight = new int[1];
+        float xScale, yScale;
+        // via technicality we actually have to divide the framebuffer
+        // size by the window size here, since glfwGetWindowContentScale
+        // returns a value not equal to 1 even on platforms where the
+        // framebuffer size and window size always map 1:1
+        glfwGetWindowSize(getWindow(), windowWidth, windowHeight);
+        glfwGetFramebufferSize(getWindow(), framebufferWidth, framebufferHeight);
+        xScale = (float)framebufferWidth[0]/windowWidth[0];
+        yScale = (float)framebufferHeight[0]/windowHeight[0];
+        return Math.max(xScale, yScale);
     }
 
     public static void setTitle(String title) {


### PR DESCRIPTION
Previous implementation was broken on hidpi platforms where the
size of the framebuffer and the size of the window correlate 1:1.
This manifested in the mouse code thinking the mouse was in a    
different location than it actually was.

New implementation explicitly calculates the ratio between the   
framebuffer size and the window size, rather than relying on
`glfwGetWindowContentScale`.

Tested on X11 and Wayland, should work on Windows

Still a minor issue of the screen not resizing properly after exiting fullscreen but the mouse still works