### PR TITLE
Improved mod-list

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -161,7 +161,7 @@ public class GuiModList extends GuiScreen
     @Override
     public void initGui()
     {
-        int slotHeight = 35;
+        int slotHeight = 25;
         for (ModContainer mod : mods)
         {
             listWidth = Math.max(listWidth,getFontRenderer().getStringWidth(mod.getName()) + 10);

--- a/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
@@ -341,6 +341,26 @@ public abstract class GuiScrollingList
             }
         }
 
+        GlStateManager.disableTexture2D();
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ZERO, GlStateManager.DestFactor.ONE);
+        GlStateManager.shadeModel(GL11.GL_SMOOTH);
+        worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldr.pos((double)this.left, (double)(this.top + 4), 0.0D).tex(0.0D, 1.0D).color(0, 0, 0, 0).endVertex();
+        worldr.pos((double)this.right, (double)(this.top + 4), 0.0D).tex(1.0D, 1.0D).color(0, 0, 0, 0).endVertex();
+        worldr.pos((double)this.right, (double)this.top, 0.0D).tex(1.0D, 0.0D).color(0, 0, 0, 255).endVertex();
+        worldr.pos((double)this.left, (double)this.top, 0.0D).tex(0.0D, 0.0D).color(0, 0, 0, 255).endVertex();
+        tess.draw();
+        worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldr.pos((double)this.left, (double)this.bottom, 0.0D).tex(0.0D, 1.0D).color(0, 0, 0, 255).endVertex();
+        worldr.pos((double)this.right, (double)this.bottom, 0.0D).tex(1.0D, 1.0D).color(0, 0, 0, 255).endVertex();
+        worldr.pos((double)this.right, (double)(this.bottom - 4), 0.0D).tex(1.0D, 0.0D).color(0, 0, 0, 0).endVertex();
+        worldr.pos((double)this.left, (double)(this.bottom - 4), 0.0D).tex(0.0D, 0.0D).color(0, 0, 0, 0).endVertex();
+        tess.draw();
+        GlStateManager.shadeModel(GL11.GL_FLAT);
+        GlStateManager.disableBlend();
+        GlStateManager.enableTexture2D();
+
         GlStateManager.disableDepth();
 
         int extraHeight = (this.getContentHeight() + border) - viewHeight;

--- a/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
@@ -80,7 +80,7 @@ public class GuiSlotModList extends GuiScrollingList
     @Override
     protected int getContentHeight()
     {
-        return (this.getSize()) * 35 + 1;
+        return (this.getSize()) * 25 + 1;
     }
 
     ArrayList<ModContainer> getMods()
@@ -101,13 +101,11 @@ public class GuiSlotModList extends GuiScrollingList
         {
             font.drawString(font.trimStringToWidth(name,       listWidth - 10), this.left + 3 , top +  2, 0xFF2222);
             font.drawString(font.trimStringToWidth(version,    listWidth - (5 + height)), this.left + 3 , top + 12, 0xFF2222);
-            font.drawString(font.trimStringToWidth("DISABLED", listWidth - 10), this.left + 3 , top + 22, 0xFF2222);
         }
         else
         {
             font.drawString(font.trimStringToWidth(name,    listWidth - 10), this.left + 3 , top +  2, 0xFFFFFF);
             font.drawString(font.trimStringToWidth(version, listWidth - (5 + height)), this.left + 3 , top + 12, 0xCCCCCC);
-            font.drawString(font.trimStringToWidth(mc.getMetadata() != null ? mc.getMetadata().getChildModCountString() : "Metadata not found", listWidth - 10), this.left + 3 , top + 22, 0xCCCCCC);
 
             if (vercheck.status.shouldDraw())
             {


### PR DESCRIPTION
This simple and small PR aims at improving the mod-list.

This mainly removes the redundant third line in the modlist, here is what it could show and why it was redundant:
1. `DISABLED` if the mod is disabled, redundant because the text is already red and the button supposedly is toggled
2. `Metadata not found` I have never seen this, and I’m not sure why you would want it there, but it exists for a null check of the next one
3. `X child mods` or `No child mods` this is redundant as well because the "details pane" already shows the number of child mods and their info

Removing this line makes the mod-list a third smaller while not removing any information, which I think is a welcomed improvement.

It also adds the fade overlay at the bottom and top of the list found in every similar GUI in the game, it is a simple copy paste, but nice for consistency.
![image](https://github.com/user-attachments/assets/e71eaff0-d975-4a05-b68a-aa03523bd0d0)

While this is a small PR I would be willing to extend it further if any doable ideas arise.