### PR TITLE
Improve the mod list again

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -421,7 +421,12 @@ public class GuiModList extends GuiScreen
                 configModButton.enabled = guiFactory.hasConfigGui();
             }
             lines.add(selectedMod.getMetadata().name);
-            lines.add(String.format("Version: %s (%s)", selectedMod.getDisplayVersion(), selectedMod.getVersion()));
+            if (selectedMod.getDisplayVersion().isEmpty())
+                lines.add(String.format("Version: %s (%s)", selectedMod.getVersion()));
+            else if (selectedMod.getVersion().equals(selectedMod.getDisplayVersion()))
+                lines.add(String.format("Version: %s", selectedMod.getDisplayVersion()));
+            else
+                lines.add(String.format("Version: %s (%s)", selectedMod.getDisplayVersion(), selectedMod.getVersion()));
             lines.add(String.format("Mod ID: '%s' Mod State: %s", selectedMod.getModId(), Loader.instance().getModState(selectedMod)));
 
             if (!selectedMod.getMetadata().credits.isEmpty())
@@ -429,12 +434,12 @@ public class GuiModList extends GuiScreen
                 lines.add("Credits: " + selectedMod.getMetadata().credits);
             }
 
-            lines.add("Authors: " + selectedMod.getMetadata().getAuthorList());
-            lines.add("URL: " + selectedMod.getMetadata().url);
+            if (!selectedMod.getMetadata().getAuthorList().isEmpty())
+                lines.add("Authors: " + selectedMod.getMetadata().getAuthorList());
+            if (!selectedMod.getMetadata().url.isEmpty())
+                lines.add("URL: " + selectedMod.getMetadata().url);
 
-            if (selectedMod.getMetadata().childMods.isEmpty())
-                lines.add("No child mods for this mod");
-            else
+            if (!selectedMod.getMetadata().childMods.isEmpty())
                 lines.add("Child mods: " + selectedMod.getMetadata().getChildModList());
 
             if (vercheck.status == Status.OUTDATED || vercheck.status == Status.BETA_OUTDATED)

--- a/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
@@ -93,7 +93,7 @@ public class GuiSlotModList extends GuiScrollingList
     {
         ModContainer mc       = mods.get(idx);
         String       name     = StringUtils.stripControlCodes(mc.getName());
-        String       version  = StringUtils.stripControlCodes(mc.getDisplayVersion());
+        String       version  = StringUtils.stripControlCodes(mc.getDisplayVersion().isEmpty() ? mc.getVersion() : mc.getDisplayVersion());
         FontRenderer font     = this.parent.getFontRenderer();
         CheckResult  vercheck = ForgeVersion.getResult(mc);
 


### PR DESCRIPTION
This time I’m improving the mod list details panel, simply by not showing lines for information that simply doesn’t exist.

Before:
![image](https://github.com/user-attachments/assets/3ca1e9ce-c4c6-466c-a0f2-e4d8d3b1807b)
After:
![image](https://github.com/user-attachments/assets/f42be618-4a2a-4d86-badb-c8b1e3323f5a)

---

Before:
![image](https://github.com/user-attachments/assets/84becdfd-92a7-4faf-9053-94054842bd3b)
After:
![image](https://github.com/user-attachments/assets/620328c3-e492-4f1a-b226-62c024ccaa9d)

---

Before:
![image](https://github.com/user-attachments/assets/3cf9ff84-ee88-4469-b60a-fc71a3de94c4)
After:
![image](https://github.com/user-attachments/assets/c578d396-f365-4f90-a392-8406428cdd8a)


This also fixes a minor bug were for the modlist sometime the versio is missing, when it actually exists.

Before:
![image](https://github.com/user-attachments/assets/a4c76898-fd9b-4f33-abcf-2943426a018d)
Now it would just show `3.0`