### PR TITLE
MethodHandle based `IEventListener` creation

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
@@ -19,31 +19,17 @@
 
 package net.minecraftforge.fml.common.eventhandler;
 
-import static org.objectweb.asm.Opcodes.*;
-
-import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
-import java.util.HashMap;
 
-import net.minecraft.launchwrapper.Launch;
-import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.ModContainer;
 
 import org.apache.logging.log4j.ThreadContext;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
-
-import com.google.common.collect.Maps;
 
 public class ASMEventHandler implements IEventListener
 {
-    private static int IDs = 0;
-    private static final String HANDLER_DESC = Type.getInternalName(IEventListener.class);
-    private static final String HANDLER_FUNC_DESC = Type.getMethodDescriptor(IEventListener.class.getDeclaredMethods()[0]);
-    private static final HashMap<Method, Class<?>> cache = Maps.newHashMap();
     private static final boolean GETCONTEXT = Boolean.parseBoolean(System.getProperty("fml.LogContext", "false"));
 
     private final IEventListener handler;
@@ -61,10 +47,11 @@ public class ASMEventHandler implements IEventListener
     public ASMEventHandler(Object target, Method method, ModContainer owner, boolean isGeneric) throws Exception
     {
         this.owner = owner;
-        if (Modifier.isStatic(method.getModifiers()))
-            handler = (IEventListener)createWrapper(method).newInstance();
-        else
-            handler = (IEventListener)createWrapper(method).getConstructor(Object.class).newInstance(target);
+        handler = EventListenerFactory.createRawListener(
+            method,
+            Modifier.isStatic(method.getModifiers()),
+            target
+        );
         subInfo = method.getAnnotation(SubscribeEvent.class);
         readable = "ASM: " + target + " " + method.getName() + Type.getMethodDescriptor(method);
         if (isGeneric)
@@ -100,83 +87,6 @@ public class ASMEventHandler implements IEventListener
     public EventPriority getPriority()
     {
         return subInfo.priority();
-    }
-
-    public Class<?> createWrapper(Method callback)
-    {
-        if (cache.containsKey(callback))
-        {
-            return cache.get(callback);
-        }
-
-        ClassWriter cw = new ClassWriter(0);
-        MethodVisitor mv;
-
-        boolean isStatic = Modifier.isStatic(callback.getModifiers());
-        boolean isInterface = callback.getDeclaringClass().isInterface();
-        String name = getUniqueName(callback);
-        String desc = name.replace('.',  '/');
-        String instType = Type.getInternalName(callback.getDeclaringClass());
-        String eventType = Type.getInternalName(callback.getParameterTypes()[0]);
-    /*
-        System.out.println("Class     " + callback.getDeclaringClass().getName());
-        System.out.println("Name:     " + name);
-        System.out.println("Desc:     " + desc);
-        System.out.println("InstType: " + instType);
-        System.out.println("Callback: " + callback.getName() + Type.getMethodDescriptor(callback));
-        System.out.println("Event:    " + eventType);
-    */
-
-        cw.visit(V21, ACC_PUBLIC | ACC_SUPER, desc, null, "java/lang/Object", new String[]{ HANDLER_DESC });
-
-        cw.visitSource(".dynamic", null);
-        {
-            if (!isStatic)
-                cw.visitField(ACC_PUBLIC, "instance", "Ljava/lang/Object;", null, null).visitEnd();
-        }
-        {
-            mv = cw.visitMethod(ACC_PUBLIC, "<init>", isStatic ? "()V" : "(Ljava/lang/Object;)V", null, null);
-            mv.visitCode();
-            mv.visitVarInsn(ALOAD, 0);
-            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-            if (!isStatic)
-            {
-                mv.visitVarInsn(ALOAD, 0);
-                mv.visitVarInsn(ALOAD, 1);
-                mv.visitFieldInsn(PUTFIELD, desc, "instance", "Ljava/lang/Object;");
-            }
-            mv.visitInsn(RETURN);
-            mv.visitMaxs(2, 2);
-            mv.visitEnd();
-        }
-        {
-            mv = cw.visitMethod(ACC_PUBLIC, "invoke", HANDLER_FUNC_DESC, null, null);
-            mv.visitCode();
-            mv.visitVarInsn(ALOAD, 0);
-            if (!isStatic)
-            {
-                mv.visitFieldInsn(GETFIELD, desc, "instance", "Ljava/lang/Object;");
-                mv.visitTypeInsn(CHECKCAST, instType);
-            }
-            mv.visitVarInsn(ALOAD, 1);
-            mv.visitTypeInsn(CHECKCAST, eventType);
-            mv.visitMethodInsn(isStatic ? INVOKESTATIC : INVOKEVIRTUAL, instType, callback.getName(), Type.getMethodDescriptor(callback), isInterface);
-            mv.visitInsn(RETURN);
-            mv.visitMaxs(2, 2);
-            mv.visitEnd();
-        }
-        cw.visitEnd();
-        Class<?> ret = Launch.classLoader.defineClass(name, cw.toByteArray());
-        cache.put(callback, ret);
-        return ret;
-    }
-
-    private String getUniqueName(Method callback)
-    {
-        return String.format("%s_%d_%s_%s_%s", getClass().getName(), IDs++,
-                callback.getDeclaringClass().getSimpleName(),
-                callback.getName(),
-                callback.getParameterTypes()[0].getSimpleName());
     }
 
     public String toString()

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
@@ -1,0 +1,111 @@
+package net.minecraftforge.fml.common.eventhandler;
+
+import org.jspecify.annotations.Nullable;
+
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author ZZZank
+ */
+class EventListenerFactory {
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+    private static final Map<Method, MethodHandle> LISTENER_FACTORIES = new ConcurrentHashMap<>();
+
+    public static IEventListener createListener(
+        Object instance,
+        Method method,
+        boolean isGeneric
+    ) {
+        var isStatic = Modifier.isStatic(method.getModifiers());
+
+        var listener = createRawListener(method, isStatic, instance);
+
+        if (isGeneric) {
+            var type = method.getGenericParameterTypes()[0];
+            if (type instanceof ParameterizedType parameterized) {
+                var filter = parameterized.getActualTypeArguments()[0];
+                var originalListener = listener;
+                listener = event -> {
+                    if (!event.isCancelable()
+                        || !event.isCanceled()
+                        || filter == ((IGenericEvent<?>) event).getGenericType()
+                    ) {
+                        originalListener.invoke(event);
+                    }
+                };
+            }
+        } else {
+            var originalListener = listener;
+            listener = event -> {
+                if (!event.isCancelable() || !event.isCanceled()) {
+                    originalListener.invoke(event);
+                }
+            };
+        }
+
+        return listener;
+    }
+
+    private static IEventListener createRawListener(Method method, boolean isStatic, @Nullable Object instance) {
+        var listenerFactory = LISTENER_FACTORIES.computeIfAbsent(
+            method,
+            ignored -> createListenerFactory(
+                method,
+                isStatic,
+                instance
+            )
+        );
+
+        try {
+            return (IEventListener) (isStatic
+                ? listenerFactory.invokeExact()
+                : listenerFactory.invokeExact(instance));
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    private static MethodHandle createListenerFactory(
+        Method callback,
+        boolean isStatic,
+        @Nullable Object instance
+    ) {
+        try {
+            var handle = LOOKUP.unreflect(callback);
+            var factoryType = isStatic
+                ? Constants.RETURNS_IT
+                : Constants.RETURNS_IT.insertParameterTypes(0, Objects.requireNonNull(instance).getClass());
+            var factoryHandle = LambdaMetafactory.metafactory(
+                LOOKUP,
+                Constants.METHOD_NAME,
+                factoryType,
+                Constants.METHOD_TYPE,
+                handle,
+                isStatic ? handle.type() : handle.type().dropParameterTypes(0, 1)
+            ).getTarget();
+            return isStatic
+                ? factoryHandle
+                : factoryHandle.asType(factoryType.changeParameterType(0, Object.class));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    interface Constants {
+        Class<?> CLAZZ = IEventListener.class;
+        Method METHOD = CLAZZ.getMethods()[0];
+        String METHOD_NAME = METHOD.getName();
+        MethodType METHOD_TYPE = MethodType.methodType(METHOD.getReturnType(), METHOD.getParameterTypes());
+        MethodType RETURNS_IT = MethodType.methodType(CLAZZ);
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
@@ -30,9 +30,9 @@ class EventListenerFactory {
         );
 
         try {
-            return (IEventListener) (isStatic
-                ? listenerFactory.invokeExact()
-                : listenerFactory.invokeExact(instance));
+            return isStatic
+                ? (IEventListener) listenerFactory.invokeExact()
+                : (IEventListener) listenerFactory.invokeExact(instance);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
@@ -1,14 +1,11 @@
 package net.minecraftforge.fml.common.eventhandler;
 
-import org.jspecify.annotations.Nullable;
-
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -19,7 +16,7 @@ class EventListenerFactory {
 
     private static final Map<Method, MethodHandle> LISTENER_FACTORIES = new ConcurrentHashMap<>();
 
-    public static IEventListener createRawListener(Method method, boolean isStatic, @Nullable Object instance) {
+    public static IEventListener createRawListener(Method method, boolean isStatic, Object instance) {
         var listenerFactory = LISTENER_FACTORIES.computeIfAbsent(
             method,
             ignored -> createListenerFactory(

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/IContextSetter.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/IContextSetter.java
@@ -21,10 +21,12 @@ package net.minecraftforge.fml.common.eventhandler;
 
 import net.minecraftforge.fml.common.ModContainer;
 
-//Instructs event handlers to set the active mod container.
-//This has a major performance impact so use sparingly.
-//Note: The context IS NOT thread aware as this would be ungodly slow.
-//So This should ONLY be used for Forge mod lifecycle events.
+/**
+ * Instructs event handlers to set the active mod container.
+ * This has a major performance impact so use sparingly.
+ * Note: The context IS NOT thread aware as this would be ungodly slow.
+ * So This should ONLY be used for Forge mod lifecycle events.
+ */
 public interface IContextSetter
 {
     default void setModContainer(ModContainer mod){};

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.fml.common.eventhandler;
+
+import net.minecraftforge.fml.common.eventhandler.impl.ExampleEvent;
+import net.minecraftforge.fml.common.eventhandler.impl.ExampleListeners;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * @author ZZZank
+ */
+public class EventBusTest {
+    public static final EventBus BUS = new EventBus();
+
+    @Test
+    public void registerInstance() {
+        var listeners = new ExampleListeners();
+        BUS.register(listeners);
+
+        var event = new ExampleEvent();
+        BUS.post(event);
+
+        Assertions.assertEquals(event.id, listeners.recorded);
+        Assertions.assertEquals(
+            List.of(EventPriority.HIGHEST, EventPriority.NORMAL, EventPriority.LOWEST),
+            listeners.triggered
+        );
+    }
+}

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
@@ -1,7 +1,8 @@
 package net.minecraftforge.fml.common.eventhandler;
 
 import net.minecraftforge.fml.common.eventhandler.impl.ExampleEvent;
-import net.minecraftforge.fml.common.eventhandler.impl.ExampleListeners;
+import net.minecraftforge.fml.common.eventhandler.impl.InstanceListeners;
+import net.minecraftforge.fml.common.eventhandler.impl.StaticListeners;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -11,20 +12,37 @@ import java.util.List;
  * @author ZZZank
  */
 public class EventBusTest {
-    public static final EventBus BUS = new EventBus();
 
     @Test
     public void registerInstance() {
-        var listeners = new ExampleListeners();
-        BUS.register(listeners);
+        var bus = new EventBus();
+
+        var listeners = new InstanceListeners();
+        bus.register(listeners);
 
         var event = new ExampleEvent();
-        BUS.post(event);
+        bus.post(event);
 
         Assertions.assertEquals(event.id, listeners.recorded);
         Assertions.assertEquals(
             List.of(EventPriority.HIGHEST, EventPriority.NORMAL, EventPriority.LOWEST),
             listeners.triggered
+        );
+    }
+
+    @Test
+    public void registerStatic() {
+        var bus = new EventBus();
+
+        bus.register(StaticListeners.class);
+
+        var event = new ExampleEvent();
+        bus.post(event);
+
+        Assertions.assertEquals(event.id, StaticListeners.recorded);
+        Assertions.assertEquals(
+            List.of(EventPriority.HIGHEST, EventPriority.NORMAL, EventPriority.LOWEST),
+            StaticListeners.triggered
         );
     }
 }

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/ExampleEvent.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/ExampleEvent.java
@@ -1,0 +1,16 @@
+package net.minecraftforge.fml.common.eventhandler.impl;
+
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * @author ZZZank
+ */
+public class ExampleEvent extends Event {
+    public static int CURRENT_ID = 0;
+
+    public final int id;
+
+    public ExampleEvent() {
+        this.id = CURRENT_ID++;
+    }
+}

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/ExampleListeners.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/ExampleListeners.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.fml.common.eventhandler.impl;
+
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author ZZZank
+ */
+public class ExampleListeners {
+    public int recorded = -1;
+    public List<EventPriority> triggered = new ArrayList<>();
+    public EventPriority stage;
+
+    @SubscribeEvent
+    public void recordId(ExampleEvent event) {
+        recorded = event.id;
+        setStage(EventPriority.NORMAL);
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void recordIdHigher(ExampleEvent event) {
+        recorded = event.id;
+        setStage(EventPriority.HIGHEST);
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void recordIdLower(ExampleEvent event) {
+        recorded = event.id;
+        setStage(EventPriority.LOWEST);
+    }
+
+    public void shouldNotRegister(ExampleEvent event) {
+        recorded = -1;
+        setStage(null);
+    }
+
+    private void setStage(EventPriority stage) {
+        this.stage = stage;
+        this.triggered.add(stage);
+    }
+}

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/InstanceListeners.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/InstanceListeners.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.fml.common.eventhandler.impl;
+
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author ZZZank
+ */
+public class InstanceListeners {
+    public int recorded = -1;
+    public List<EventPriority> triggered = new ArrayList<>();
+    public EventPriority stage;
+
+    @SubscribeEvent
+    public void recordId(ExampleEvent event) {
+        recorded = event.id;
+        setStage(EventPriority.NORMAL);
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void recordIdHigher(ExampleEvent event) {
+        recorded = event.id;
+        setStage(EventPriority.HIGHEST);
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void recordIdLower(ExampleEvent event) {
+        recorded = event.id;
+        setStage(EventPriority.LOWEST);
+    }
+
+    public void shouldNotRegister(ExampleEvent event) {
+        recorded = -1;
+        setStage(null);
+    }
+
+    private void setStage(EventPriority stage) {
+        this.stage = stage;
+        this.triggered.add(stage);
+    }
+}

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/StaticListeners.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/StaticListeners.java
@@ -9,36 +9,36 @@ import java.util.List;
 /**
  * @author ZZZank
  */
-public class ExampleListeners {
-    public int recorded = -1;
-    public List<EventPriority> triggered = new ArrayList<>();
-    public EventPriority stage;
+public class StaticListeners {
+    public static int recorded = -1;
+    public static List<EventPriority> triggered = new ArrayList<>();
+    public static EventPriority stage;
 
     @SubscribeEvent
-    public void recordId(ExampleEvent event) {
+    public static void recordId(ExampleEvent event) {
         recorded = event.id;
         setStage(EventPriority.NORMAL);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public void recordIdHigher(ExampleEvent event) {
+    public static void recordIdHigher(ExampleEvent event) {
         recorded = event.id;
         setStage(EventPriority.HIGHEST);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void recordIdLower(ExampleEvent event) {
+    public static void recordIdLower(ExampleEvent event) {
         recorded = event.id;
         setStage(EventPriority.LOWEST);
     }
 
-    public void shouldNotRegister(ExampleEvent event) {
+    public static void shouldNotRegister(ExampleEvent event) {
         recorded = -1;
         setStage(null);
     }
 
-    private void setStage(EventPriority stage) {
-        this.stage = stage;
-        this.triggered.add(stage);
+    private static void setStage(EventPriority stage) {
+        StaticListeners.stage = stage;
+        triggered.add(stage);
     }
 }


### PR DESCRIPTION
- `Method` -> `IEventListener` is now done by  `java.lang.invoke.LambdaMetafactory` instead of defining class on the fly.
  - A utility class `EventListenerFactory` for handling event listener creation
  - For `Method` object not resolved before, a listener factory in the form of `MethodHandle` will be created. The factory will be applied on the provided `instance`, or simple `factory.invokeExact()` if static method is provided.
  - The cache mechanism is similar to before. If the same `Method` object to `EventListenerFactory` multiple times, the first factory for this method will be reused
- generic filter check will not be applied to listeners for non-generic events (aka most events)