### PR TITLE
fix javadoc for `RegistryEvent` and `AttachCapabilitiesEvent`

### DIFF
--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -31,7 +31,7 @@ import net.minecraftforge.fml.common.eventhandler.GenericEvent;
 /**
  * Fired whenever an object with Capabilities support {currently TileEntity/Item/Entity)
  * is created. Allowing for the attachment of arbitrary capability providers.
- *
+ * <p>
  * Please note that as this is fired for ALL object creations efficient code is recommended.
  * And if possible use one of the sub-classes to filter your intended objects.
  */
@@ -57,6 +57,7 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
 
     /**
      * Adds a capability to be attached to this object.
+     * <p>
      * Keys MUST be unique, it is suggested that you set the domain to your mod ID.
      * If the capability is an instance of INBTSerializable, this key will be used when serializing this capability.
      *
@@ -71,7 +72,7 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
     }
 
     /**
-     * A unmodifiable view of the capabilities that will be attached to this object.
+     * An unmodifiable view of the capabilities that will be attached to this object.
      */
     public Map<ResourceLocation, ICapabilityProvider> getCapabilities()
     {

--- a/src/main/java/net/minecraftforge/event/RegistryEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegistryEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import net.minecraftforge.registries.RegistryBuilder;
 import org.apache.commons.lang3.Validate;
 
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,7 @@ public class RegistryEvent<T extends IForgeRegistryEntry<T>> extends GenericEven
         super(clazz);
     }
     /**
-     * Register new registries when you receive this event, through the {@link RecipeBuilder}
+     * Register new registries when you receive this event, through the {@link RegistryBuilder#create()}
      */
     public static class NewRegistry extends Event
     {
@@ -51,12 +52,12 @@ public class RegistryEvent<T extends IForgeRegistryEntry<T>> extends GenericEven
 
     /**
      * Register your objects for the appropriate registry type when you receive this event.
-     *
+     * <p>
      * <code>event.getRegistry().register(...)</code>
-     *
+     * <p>
      * The registries will be visited in alphabetic order of their name, except blocks and items,
      * which will be visited FIRST and SECOND respectively.
-     *
+     * <p>
      * ObjectHolders will reload between Blocks and Items, and after all registries have been visited.
      * @param <T> The registry top level type
      */


### PR DESCRIPTION
- the `RecipeBuilder` link in `RegistryEvent` is actually `RegistryBuilder`, it's further clarified by pointing to exact registration method `RegistryBuilder#create()`
- and some minor fix for line break

(The question of "What the * is RecipeBuilder" has been haunting me since the first time I try to use registry, finally figured that out)