### PR TITLE
Optimize event handler class scanning

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
@@ -14,17 +14,11 @@ import java.util.concurrent.ConcurrentHashMap;
 class EventListenerFactory {
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
-    private static final Map<Method, MethodHandle> LISTENER_FACTORIES = new ConcurrentHashMap<>();
-
     public static IEventListener createRawListener(Method method, boolean isStatic, Object instance) {
-        var listenerFactory = LISTENER_FACTORIES.computeIfAbsent(
-            method,
-            ignored -> createListenerFactory(
-                method,
-                isStatic,
-                instance
-            )
-        );
+        // no caching is applied here because in EventBus scenario, caching will only be useful
+        // when two instance-based listeners of the same class are registered, which is an
+        // incredibly rare usage in 1.12 Forge environment
+        var listenerFactory = createListenerFactory(method, isStatic, instance);
 
         try {
             return isStatic


### PR DESCRIPTION
- Added a shortcut in method scanning that will skip `cls.getDeclaredMethod(method.getName(), method.getParameterTypes())` when the `cls` is exactly the parent of `method`, all static listeners and most instance listeners will take this shortcut
- `method.getParameterTypes()` is cached to prevent array copying
- The cache in `EventListenerFactory` is removed
```java
        // no caching is applied here because in EventBus scenario, caching will only be useful
        // when multiple instance-based listeners of the same class are registered, which is an
        // incredibly rare usage in 1.12 Forge environment
        var listenerFactory = createListenerFactory(method, isStatic, instance);
```

## JMH benchmark
```
Benchmark                               Mode  Cnt    Score     Error  Units
BusPerformanceTest.register10000Modern  avgt    5  769.841 ± 246.200  ms/op
```
Result for last PR:
```
Benchmark                               Mode  Cnt     Score     Error  Units
BusPerformanceTest.register10000Modern  avgt    5  1058.961 ± 173.586  ms/op
```

About 37.55% faster.

result is uploaded to the same branch as the one in last PR: https://github.com/ZZZank/Cleanroom/tree/event-hus-benchmark/benchmark-result