### PR TITLE
Remove the configuration file registration restriction.

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -384,11 +384,6 @@ public class ConfigManager
      * @param configClass configuration class that is annotated with {@link Config}
      */
     public static void register(Class<?> configClass) {
-        if (Launch.classLoader.isClassLoaded("net.minecraftforge.fml.common.Loader")) {
-            if (Loader.instance().hasReachedState(LoaderState.PREINITIALIZATION)) {
-                throw new RuntimeException("Please call this method before pre-init!");
-            }
-        }
         Config config = configClass.getAnnotation(Config.class);
         String modId = config.modid();
         Set<Class<?>> modConfigClasses = MOD_CONFIG_CLASSES.computeIfAbsent(modId, k -> Sets.newHashSet());


### PR DESCRIPTION
This method is for classes without ASMData.
1. In addition to Coremod, dynamically generated classes also need to use it.
2. Synchronization in general, such as the following code, does not work properly due to the lack of ASMDataTable. And we cannot use it when synchronization is required.
```java
     @SubscribeEvent
     public static void onConfigChanged(final ConfigChangedEvent.OnConfigChangedEvent event) {
            if (Reference.MODID.equals(event.getModID())) {
                ConfigManager.sync(Reference.MODID, Config.Type.INSTANCE); // Want to sync the data in class
            }
        }
```
(the `register(Class)` has the same function of sync...)