### PR TITLE
Reduce allocation in `ListenerList`

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ListenerList.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ListenerList.java
@@ -139,6 +139,9 @@ public class ListenerList
 
     private static class ListenerListInst
     {
+        private static final EventPriority[] PRIORITIES = EventPriority.values();
+        private static final IEventListener[] EMPTY_LISTENER_ARRAY = new IEventListener[0];
+
         private boolean rebuild = true;
         private IEventListener[] listeners;
         private final ArrayList<IEventListener>[] priorities;
@@ -148,7 +151,7 @@ public class ListenerList
 
         private ListenerListInst()
         {
-            priorities = new ArrayList[EventPriority.values().length];
+            priorities = new ArrayList[PRIORITIES.length];
         }
 
         public void dispose()
@@ -230,7 +233,7 @@ public class ListenerList
         private void addChild(ListenerListInst child)
         {
             if (this.children == null)
-                this.children = Lists.newArrayList();
+                this.children = new ArrayList<>();
             this.children.add(child);
         }
 
@@ -245,7 +248,7 @@ public class ListenerList
             }
 
             ArrayList<IEventListener> ret = new ArrayList<IEventListener>();
-            for (EventPriority value : EventPriority.values())
+            for (EventPriority value : PRIORITIES)
             {
                 List<IEventListener> listeners = getListeners(value);
                 if (!listeners.isEmpty())
@@ -254,7 +257,7 @@ public class ListenerList
                     ret.addAll(listeners);
                 }
             }
-            listeners = ret.toArray(new IEventListener[0]);
+            listeners = ret.toArray(EMPTY_LISTENER_ARRAY);
             rebuild = false;
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ListenerList.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ListenerList.java
@@ -32,7 +32,7 @@ public class ListenerList
     private static int maxSize = 0;
 
     @Nullable
-    private ListenerList parent;
+    private final ListenerList parent;
     private ListenerListInst[] lists = new ListenerListInst[0];
 
     public ListenerList()
@@ -177,7 +177,7 @@ public class ListenerList
          * The list is returned with the listeners for the children events first.
          *
          * @param priority The Priority to get
-         * @return ArrayList containing listeners
+         * @return a list containing listeners for this event, with no guarantee on the mutability of ths list
          */
         public List<IEventListener> getListeners(EventPriority priority)
         {
@@ -264,15 +264,17 @@ public class ListenerList
         public void register(EventPriority priority, IEventListener listener)
         {
             var byPriority = priorities[priority.ordinal()];
+
             if (byPriority == null) {
                 synchronized (priorities) {
-                    byPriority = priorities[priority.ordinal()];
+                    byPriority = priorities[priority.ordinal()]; // in case another thread already triggered initialization
                     if (byPriority == null) {
                         byPriority = new ArrayList<>();
                         priorities[priority.ordinal()] = byPriority;
                     }
                 }
             }
+
             byPriority.add(listener);
             this.forceRebuild();
         }

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ListenerList.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ListenerList.java
@@ -137,7 +137,7 @@ public class ListenerList
         }
     }
 
-    private class ListenerListInst
+    private static class ListenerListInst
     {
         private boolean rebuild = true;
         private IEventListener[] listeners;


### PR DESCRIPTION
- `ListenerListInst` is marked as static class, saving one field referencing `ListenerList`.
- The list storing listeners by priority is now lazily initialized, since most listeners are only using default priority.
- Some readonly constants (`EventPriority.values()` for example) are cached to prevent allocation at each usage.

---

EDIT: This should be the last eventbus related PR before trying to switch to EventBus7