### PR TITLE
Fix event listener registration for method with non-void return type

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
@@ -99,7 +99,9 @@ public class EventBus implements IEventExceptionHandler
             try {
                 // do `.getDeclaredMethod(...)` to force JVM to walk through declared methods and load their parameter
                 // types. This is for preventing shortcut below from skipping classloading
-                // related issue: https://github.com/CleanroomMC/Cleanroom/issues/349 , not strictly our fault, but :(
+                //
+                // mod developers should be responsible for not loading non-existent class, but :(
+                // related issue: https://github.com/CleanroomMC/Cleanroom/issues/349
                 method.getDeclaringClass().getDeclaredMethod("forceClassLoadingForDeclaredMethods", Event.class);
             } catch (NoSuchMethodException e) {
                 // swallow this specific exception, other exceptions, like ClassNotFoundException, will fall through

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventListenerFactory.java
@@ -48,7 +48,7 @@ class EventListenerFactory {
                 factoryType,
                 Constants.METHOD_TYPE,
                 handle,
-                isStatic ? handle.type() : handle.type().dropParameterTypes(0, 1)
+                MethodType.methodType(void.class, handle.type().parameterType(isStatic ? 0 : 1))
             ).getTarget();
 
             return isStatic

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.fml.common.eventhandler;
 
+import net.minecraftforge.fml.common.eventhandler.impl.AbnormalListeners;
 import net.minecraftforge.fml.common.eventhandler.impl.ExampleEvent;
 import net.minecraftforge.fml.common.eventhandler.impl.InstanceListeners;
 import net.minecraftforge.fml.common.eventhandler.impl.StaticListeners;
@@ -44,5 +45,17 @@ public class EventBusTest {
             List.of(EventPriority.HIGHEST, EventPriority.NORMAL, EventPriority.LOWEST),
             StaticListeners.triggered
         );
+    }
+
+    @Test
+    public void registerAbnormal() {
+        var bus = new EventBus();
+
+        bus.register(AbnormalListeners.Actual.class);
+
+        var event = new ExampleEvent();
+        bus.post(event);
+
+        Assertions.assertTrue(AbnormalListeners.nonVoid, "listener with non-void return type is valid");
     }
 }

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/AbnormalListeners.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/AbnormalListeners.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.fml.common.eventhandler.impl;
+
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * @author ZZZank
+ */
+public class AbnormalListeners {
+
+    public static boolean nonVoid = false;
+
+    static class Parent {
+
+        @SubscribeEvent
+        public static void listenerParentOnly(ExampleEvent event) {
+            throw new IllegalStateException("listener method only present in super class should not be registered");
+        }
+
+        @SubscribeEvent
+        public static void listenerParentAndSub(ExampleEvent event) {
+            throw new IllegalStateException(
+                "listener method only registered in super class should not be registered in sub class");
+        }
+    }
+
+    public static class Actual extends Parent {
+
+        public static void listenerParentAndSub(ExampleEvent event) {
+            throw new IllegalStateException(
+                "listener method only registered in super class should not be registered in sub class");
+        }
+
+        /// really?
+        @SubscribeEvent
+        public static Object nonVoidReturn(ExampleEvent event) {
+            nonVoid = true;
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- Fix event listener registration for method with non-void return type
- Added test case for listener registration from non trivial methods
- Minor tweak on comments added in #350

Fixes #352