### PR TITLE
Fix `main` artifical

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1151,6 +1151,11 @@ project(':cleanroom') {
     test {
         jvmArgs jvm_arguments + compiler_jvm_arguments
     }
+
+    artifacts {
+        archives universalJar
+        archives installerJar
+    }
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
When we call `installerJar`, we will build it.
When we call `build`, nothing would be built for `main`.

Fixs this:
![image](https://github.com/user-attachments/assets/ad1024e8-0b6c-4d84-a70d-5c6c39c57539)
