### PR TITLE
Not `Repository Dispatch` when `secrets.CLEANROOMMC_DISPATCH_TOKEN` miss

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -91,7 +91,7 @@ jobs:
           if-no-files-found: error
 
       - name: Repository Dispatch
-        if: ${{ success() && github.event_name != 'pull_request' && github.repository != 'CleanroomMC/Cleanroom'}}
+        if: ${{ success() && github.event_name != 'pull_request' && secrets.CLEANROOMMC_DISPATCH_TOKEN != ''}}
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.CLEANROOMMC_DISPATCH_TOKEN }} # require PAT :shrug:

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -91,7 +91,7 @@ jobs:
           if-no-files-found: error
 
       - name: Repository Dispatch
-        if: ${{ success() && github.event_name != 'pull_request' }}
+        if: ${{ success() && github.event_name != 'pull_request' && github.repository != 'CleanroomMC/Cleanroom'}}
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.CLEANROOMMC_DISPATCH_TOKEN }} # require PAT :shrug:


### PR DESCRIPTION
Not `Repository Dispatch` when `secrets.CLEANROOMMC_DISPATCH_TOKEN` miss, 
Often it is possible to run on other repositories where you do not have permissions. eg forks