### PR TITLE
Add check for entity trackingUpdateFrequency must be positive

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityEntryBuilder.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityEntryBuilder.java
@@ -172,7 +172,7 @@ public final class EntityEntryBuilder<E extends Entity>
      * Sets entity tracking information.
      *
      * @param range The tracking range
-     * @param updateFrequency The tracking update frequency
+     * @param updateFrequency The tracking update frequency. Update period in ticks. Must be positive.
      * @param sendVelocityUpdates If the entity should send velocity updates
      * @return This builder
      */
@@ -262,7 +262,7 @@ public final class EntityEntryBuilder<E extends Entity>
         checkState(this.entity != null, "entity class not provided");
         checkState(this.id != null, "entity id not provided");
         checkState(this.name != null, "entity name not provided");
-        checkArgument(this.trackingUpdateFrequency != 0, "entity trackingUpdateFrequency could not be zero");
+        checkArgument(this.trackingUpdateFrequency > 0, "entity trackingUpdateFrequency could not be zero or negative");
         if (this.spawns != null) checkState(EntityLiving.class.isAssignableFrom(EntityEntryBuilder.this.entity), "Cannot add spawns to a non-%s", EntityLiving.class.getSimpleName());
         final BuiltEntityEntry entry = new BuiltEntityEntry(this.entity, this.name);
         entry.factory = this.factory != null ? this.factory : new ConstructorFactory<E>(this.entity) {


### PR DESCRIPTION
babysitting check that `entity trackingUpdateFrequency could not be zero`
which is hard to debug
```java
escription: Exception in server tick loop

java.lang.ArithmeticException: / by zero
	at net.minecraft.entity.EntityTrackerEntry.func_73122_a(EntityTrackerEntry.java:179)
	at net.minecraft.entity.EntityTracker.func_72788_a(EntityTracker.java:292)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:779)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:185)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
	at java.base/java.lang.Thread.run(Thread.java:1583)

```