### PR TITLE
ResourceLocationHelper

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/ResourceLocationHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/ResourceLocationHelper.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.common.util;
+
+import net.minecraft.util.ResourceLocation;
+
+public class ResourceLocationHelper {
+
+    /**
+     * Create a resourceLocation under the default namespace.
+     * For example :
+     *     ResourceLocationHelper.create("minecraft", value)
+     *     ResourceLocationHelper.of("minecraft").create(value)
+     *     new ResourceLocation(value)
+     * is equal
+     *
+     * Modder could create an instance of ResourceLocationHelper. It is very helpful.
+     * And, you could also use the static method at your api.
+     *
+     * @param defaultNamespace the default namespace
+     * @param value the value
+     * @return the resource location
+     */
+    public static ResourceLocation create(String defaultNamespace, String value) {
+        int idx = value.indexOf(':');
+        return idx > 0 ? new ResourceLocation(value.substring(0, idx), value.substring(idx +1)) : new ResourceLocation(defaultNamespace, value);
+    }
+
+    public ResourceLocation create(String value) {
+        return create(this.defaultNamespace, value);
+    }
+
+    public static ResourceLocationHelper of(String defaultNamespace) {
+        return new ResourceLocationHelper(defaultNamespace);
+    }
+  
+    private final String defaultNamespace;
+
+    private ResourceLocationHelper(String defaultNamespace) {
+        this.defaultNamespace = defaultNamespace;
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityEntryBuilder.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityEntryBuilder.java
@@ -28,6 +28,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.common.util.ResourceLocationHelper;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
@@ -151,7 +152,7 @@ public final class EntityEntryBuilder<E extends Entity>
     public final EntityEntryBuilder<E> id(@Nonnull final String id, final int network)
     {
         checkNotNull(id, "id");
-        return this.id(new ResourceLocation(id.indexOf(':') == -1 ? this.mod.getModId() + ':' + id : id), network);
+        return this.id(ResourceLocationHelper.create(this.mod.getModId(), id), network);
     }
 
     /**


### PR DESCRIPTION
Many mods have similar code for creating their own ResourceLocations. This is usually done in the main class, for example, MyMod.rc("xxx").
This PR directly imports this API, allowing us to use MyMod.rc.create("XXX")
Forge will also use this API internally, rather than checking ':' everywhere. This is especially true once this PR is merged, as #70 will be fixed.