### PR TITLE
fix dep bug: netty requests need netty-codec-compression at runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -485,6 +485,7 @@ project(':cleanroom') {
         installer "io.netty:netty-codec-http:$props.netty_version"
         installer "io.netty:netty-codec-http2:$props.netty_version"
         installer "io.netty:netty-codec-dns:$props.netty_version"
+        installer "io.netty:netty-codec-compression:$props.netty_version"
         installer "io.netty:netty-resolver-dns:$props.netty_version"
 
         installer 'org.apache.logging.log4j:log4j-api:2.25.1'


### PR DESCRIPTION
this trivial patch includes `io.netty:netty-codec-compression` as a dependency, fixing a bug where `io.netty.handler.codec.HttpContentDecompressor` has a runtime dependency on the contents of `io.netty.handler.codec.compression`.

this bug was identified in practice with ComputerCraft running under Cleanroom. executing the following lua code triggers the bug:
```lua
http.get('http://example.com')
-- returns:
--   {nil, 'Could not connect', nil}
```

and, if we set `general { B:log_computer_errors=true }` in the CC:Tweaked config, we see the following in the Minecraft logs, directing us towards the problem:
```
[00:57:22] [ComputerCraft-Netty-0/ERROR] [computercraft]: Error handling HTTP response
java.lang.NoClassDefFoundError: io/netty/handler/codec/compression/Brotli
	at io.netty.handler.codec.http.HttpContentDecompressor.newContentDecoder(HttpContentDecompressor.java:105)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:104)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:47)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:434)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:455)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:249)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:293)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:167)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:381)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:575)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysOptimized(NioIoHandler.java:550)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:491)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:468)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:206)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:177)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.lang.Thread.run(Thread.java:1570)
Caused by: java.lang.ClassNotFoundException: io.netty.handler.codec.compression.Brotli
	at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 28 more

```