### PR TITLE
Prevent loading same coremod twice

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -40,4 +40,4 @@ jobs:
         run: ./gradlew --stop
 
       - name: Publish to maven for mod development
-        run: ./gradlew publish -PoutlandUsername=${{ secrets.MAVEN_USERNAME }} -PoutlandPassword="${{ secrets.MAVEN_PASSWORD }}" -Prun_number=${{ github.run_number }}
+        run: ./gradlew publish -PcleanroomUsername=${{ secrets.MAVEN_USERNAME }} -PcleanroomPassword="${{ secrets.MAVEN_PASSWORD }}" -Prun_number=${{ github.run_number }}

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -40,4 +40,4 @@ jobs:
         run: ./gradlew --stop
 
       - name: Publish to maven for mod development
-        run: ./gradlew publish -PcleanroomUsername=${{ secrets.MAVEN_USERNAME }} -PcleanroomPassword="${{ secrets.MAVEN_PASSWORD }}" -Prun_number=${{ github.run_number }}
+        run: ./gradlew publish -PcleanroomUsername=${{ secrets.CLEANROOM_MAVEN_USERNAME }} -PcleanroomPassword="${{ secrets.CLEANROOM_MAVEN_PASSWORD }}" -Prun_number=${{ github.run_number }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -42,7 +42,7 @@ jobs:
         run: ./gradlew --stop
 
       - name: Publish to maven for mod development
-        run: ./gradlew publish -PoutlandUsername=${{ secrets.MAVEN_USERNAME }} -PoutlandPassword="${{ secrets.MAVEN_PASSWORD }}" -Prun_number=${{ github.run_number }} -Prelease=true
+        run: ./gradlew publish -PoutlandUsername=${{ secrets.CLEANROOM_MAVEN_USERNAME }} -PoutlandPassword="${{ secrets.CLEANROOM_MAVEN_PASSWORD }}" -Prun_number=${{ github.run_number }} -Prelease=true
 
       - name: setup python
         uses: actions/setup-python@v5.6.0

--- a/build.gradle
+++ b/build.gradle
@@ -1018,8 +1018,8 @@ project(':cleanroom') {
     publishing {
         repositories {
             maven {
-                name = "outland"
-                url = "https://maven.outlands.top/releases"
+                name = "cleanroom"
+                url = 'https://repo.cleanroommc.com/releases'
                 credentials(PasswordCredentials)
                 authentication {
                     basic(BasicAuthentication)

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -43,6 +43,7 @@ import org.spongepowered.asm.service.mojang.MixinServiceLaunchWrapper;
 import org.spongepowered.asm.util.Constants;
 
 import java.io.*;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.security.cert.Certificate;
 import java.util.*;
@@ -55,6 +56,7 @@ public class CoreModManager {
     private static final Attributes.Name COREMODCONTAINSFMLMOD = new Attributes.Name("FMLCorePluginContainsFMLMod");
     private static final Attributes.Name FORCELOADASMOD = new Attributes.Name("ForceLoadAsMod");
     private static final Attributes.Name MODTYPE = new Attributes.Name("ModType");
+    private static final Set<String> loadedPlugins = new HashSet<>();
     private static String[] rootPlugins = { "net.minecraftforge.fml.relauncher.FMLCorePlugin", "net.minecraftforge.classloading.FMLForgePlugin", "net.minecraftforge.fml.relauncher.MixinBooterPlugin" };
     private static List<String> ignoredModFiles = Lists.newArrayList();
     private static Map<String, List<String>> transformers = Maps.newHashMap();
@@ -546,6 +548,14 @@ public class CoreModManager {
 
     private static FMLPluginWrapper loadCoreMod(LaunchClassLoader classLoader, String coreModClass, File location)
     {
+        if (loadedPlugins.contains(coreModClass)) 
+        {
+            return null;
+        } 
+        else 
+        {
+            loadedPlugins.add(coreModClass);
+        }
         String coreModName = coreModClass.substring(coreModClass.lastIndexOf('.') + 1);
         try
         {
@@ -618,7 +628,7 @@ public class CoreModManager {
                 }
             }
 
-            IFMLLoadingPlugin plugin = (IFMLLoadingPlugin) coreModClazz.newInstance();
+            IFMLLoadingPlugin plugin = (IFMLLoadingPlugin) coreModClazz.getConstructor().newInstance();
             String accessTransformerClass = plugin.getAccessTransformerClass();
             if (accessTransformerClass != null)
             {
@@ -649,6 +659,8 @@ public class CoreModManager {
         catch (IllegalAccessException iae)
         {
             FMLLog.log.error("Coremod {}: The plugin class {} was not accessible", coreModName, coreModClass, iae);
+        } catch (InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
         }
         return null;
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -649,15 +649,13 @@ public class CoreModManager {
         {
             FMLLog.log.error("Coremod {}: The plugin {} is not an implementor of IFMLLoadingPlugin", coreModName, coreModClass, cce);
         }
-        catch (InstantiationException ie)
+        catch (InstantiationException | InvocationTargetException | NoSuchMethodException ie)
         {
             FMLLog.log.error("Coremod {}: The plugin class {} was not instantiable", coreModName, coreModClass, ie);
         }
         catch (IllegalAccessException iae)
         {
             FMLLog.log.error("Coremod {}: The plugin class {} was not accessible", coreModName, coreModClass, iae);
-        } catch (InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException(e);
         }
         return null;
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -551,10 +551,6 @@ public class CoreModManager {
         if (loadedPlugins.contains(coreModClass)) 
         {
             return null;
-        } 
-        else 
-        {
-            loadedPlugins.add(coreModClass);
         }
         String coreModName = coreModClass.substring(coreModClass.lastIndexOf('.') + 1);
         try
@@ -637,6 +633,7 @@ public class CoreModManager {
             }
             FMLPluginWrapper wrap = new FMLPluginWrapper(coreModName, plugin, location, sortIndex, dependencies);
             loadPlugins.add(wrap);
+            loadedPlugins.add(coreModClass);
             FMLLog.log.debug("Enqueued coremod {}", coreModName);
             MixinBooterPlugin.queneEarlyMixinLoader(plugin);
             return wrap;


### PR DESCRIPTION
Unimined will automatically scan and add core plugins to cli, so if you depend on a coremod all its transformers will be registered twice