### PR TITLE
Fix ItemStack#copy() not copying unserialized cap data

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -256,7 +256,7 @@
 -            itemstack.stackTagCompound = this.stackTagCompound.copy();
 +            copy.stackTagCompound = this.stackTagCompound.copy();
 +        }
-+        if (this.capNBT != null || this.capabilities != null)
++        if (this.capabilities != null)
 +        {
 +            copy.capNBT = this.capabilities.serializeNBT();
 +        }


### PR DESCRIPTION
If the original stack had capabilities initialized with some data, but wasn't written to `capNBT` yet, the copy would not retain the capability data. This makes sure original capability data is serialized to the copy if it exists.

Fixes #473. Recipe output is copied to send in `SPacketSetSlot`, but capabilities weren't being copied.