### PR TITLE
Allow registering event listening methods with illegal param type

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common.eventhandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.util.function.Consumer;
 
 import net.minecraftforge.fml.common.ModContainer;
 
@@ -32,10 +33,10 @@ public class ASMEventHandler implements IEventListener
 {
     private static final boolean GETCONTEXT = Boolean.parseBoolean(System.getProperty("fml.LogContext", "false"));
 
-    private final IEventListener handler;
+    private final Consumer<Event> handler;
     private final SubscribeEvent subInfo;
-    private ModContainer owner;
-    private String readable;
+    private final ModContainer owner;
+    private final String readable;
 
     @Deprecated
     public ASMEventHandler(Object target, Method method, ModContainer owner) throws Exception
@@ -58,7 +59,7 @@ public class ASMEventHandler implements IEventListener
             var filter = parameterized.getActualTypeArguments()[0];
             this.handler = event -> {
                 if (filter == ((IGenericEvent<?>) event).getGenericType()) {
-                    rawHandler.invoke(event);
+                    rawHandler.accept(event);
                 }
             };
         } else {
@@ -75,7 +76,7 @@ public class ASMEventHandler implements IEventListener
         {
             if (!event.isCancelable() || !event.isCanceled() || subInfo.receiveCanceled())
             {
-                handler.invoke(event);
+                handler.accept(event);
             }
         }
         if (GETCONTEXT)

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
@@ -152,6 +152,7 @@ public class EventBus implements IEventExceptionHandler
         }
     }
 
+    /// Some mods will intentionally call this method with illegal `method` object (whose param type is `Object` instead of subclass of `Event`), and we have to allow this stupid move
     private void register(Class<?> eventType, Object target, Method method, final ModContainer owner)
     {
         try

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/EventBusTest.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.fml.common.eventhandler;
 
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.eventhandler.impl.AbnormalListeners;
 import net.minecraftforge.fml.common.eventhandler.impl.ExampleEvent;
 import net.minecraftforge.fml.common.eventhandler.impl.InstanceListeners;
@@ -7,6 +9,7 @@ import net.minecraftforge.fml.common.eventhandler.impl.StaticListeners;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 /**
@@ -57,5 +60,30 @@ public class EventBusTest {
         bus.post(event);
 
         Assertions.assertTrue(AbnormalListeners.nonVoid, "listener with non-void return type is valid");
+    }
+
+    @Test
+    public void registerIllegalParamType() throws Exception {
+        var bus = new EventBus();
+
+        var listener = new AbnormalListeners.IllegalParamType();
+
+        var method = EventBus.class.getDeclaredMethod(
+            "register",
+            Class.class, Object.class, Method.class, ModContainer.class
+        );
+        method.setAccessible(true);
+        method.invoke(
+            bus,
+            ExampleEvent.class,
+            listener,
+            AbnormalListeners.IllegalParamType.class.getMethod("onEvent", Object.class),
+            Loader.instance().getMinecraftModContainer()
+        );
+
+        var event = new ExampleEvent();
+        bus.post(event);
+
+        Assertions.assertEquals(event.id, listener.captured);
     }
 }

--- a/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/AbnormalListeners.java
+++ b/src/test/java/net/minecraftforge/fml/common/eventhandler/impl/AbnormalListeners.java
@@ -37,4 +37,14 @@ public class AbnormalListeners {
             return null;
         }
     }
+
+    public static class IllegalParamType {
+        public Integer captured = null;
+
+        @SubscribeEvent
+        public void onEvent(Object event) {
+            var casted = (ExampleEvent) event;
+            captured = casted.id;
+        }
+    }
 }


### PR DESCRIPTION
Some mods (e.g. [CompatUtil in RLTweaker](https://github.com/Charles445/RLTweaker/blob/1207ef8d22cd84b9d6c83f3b7cab2b0c75c25e44/src/main/java/com/charles445/rltweaker/util/CompatUtil.java#L86)) will intentionally call private `register` method to register their event listener, even when the param type is illegal.

This PR fixed this "issue" by making `EventListenerFactory` generate `Consumer<Event>` instead of `IEventListener`, because the functional method in `Consumer` is `void accept(T t);`, whose param type class is `Object` instead of `Event`.

---

Registering event listener in this way is, in my opinion, really stupid and far from best practice, especially when you can just create a new class with legal param type, and prevent loading non-existent event classes by simply not using such class:
```java
class OptionalEventHandler {
    public static void optionalEvent(SomeOptionalEvent event) {
        // ...
    }
}

if (modLoaded("some_mod_that_provides_optional_event")) {
    MinecraftForge.EVENT_BUS.register(OptionalEventHandler.class);
}
```