### PR TITLE
Fix 'outdated server' showing in ping before server fully boots

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -647,7 +647,8 @@ public class FMLCommonHandler
         if (!shouldAllowPlayerLogins())
         {
             TextComponentString text = new TextComponentString("Server is still starting! Please wait before reconnecting.");
-            if (packet.getRequestedState() != EnumConnectionState.STATUS) {
+            if (packet.getRequestedState() != EnumConnectionState.STATUS)
+            {
                 FMLLog.log.info("Disconnecting Player: {}", text.getUnformattedText());
                 manager.sendPacket(new SPacketDisconnect(text));
             }


### PR DESCRIPTION
Sending the disconnect packet in `STATUS` stage will cause the client to display `Outdated Server` in ping.