### PR TITLE
Don't report mods with no fingerprinting as potentially tampered with

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -95,6 +95,7 @@ public class FMLModContainer implements ModContainer
 
     private String annotationDependencies;
     private VersionRange minecraftAccepted;
+    private boolean hasExpectedFingerprint;
     private boolean fingerprintNotPresent;
     private Set<String> sourceFingerprints;
     private Certificate certificate;
@@ -177,6 +178,10 @@ public class FMLModContainer implements ModContainer
             }
         }
         return languageAdapter;
+    }
+
+    public boolean hasExpectedFingerprint() {
+        return hasExpectedFingerprint;
     }
 
     public boolean isFingerprintNotPresent() {
@@ -574,6 +579,7 @@ public class FMLModContainer implements ModContainer
 
         if (expectedFingerprint != null && !expectedFingerprint.isEmpty())
         {
+            hasExpectedFingerprint = true;
             if (!sourceFingerprints.contains(expectedFingerprint))
             {
                 Level warnLevel = source.isDirectory() ? Level.TRACE : Level.ERROR;

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -387,7 +387,7 @@ public class LoadController
                 mc.getSource().getName()
             );
 
-            if (mc instanceof FMLModContainer fmc && fmc.isFingerprintNotPresent())
+            if (mc instanceof FMLModContainer fmc && fmc.hasExpectedFingerprint() && fmc.isFingerprintNotPresent())
                 potentiallyTamperedMod.add(fmc.getSource().getName());
         }
 


### PR DESCRIPTION
This removes mods with no expected fingerprint from the potentially tampered with section of crash reports.

To do that, I’ve added a public getter method (could be changed to protected) `FMLModContainer#hasExpectedFingerprint()`