### PR TITLE
Guard console appender against writing to a closed terminal during shutdown

### DIFF
--- a/src/main/java/net/minecraftforge/server/terminalconsole/TerminalConsoleAppender.java
+++ b/src/main/java/net/minecraftforge/server/terminalconsole/TerminalConsoleAppender.java
@@ -321,7 +321,6 @@ public class TerminalConsoleAppender extends AbstractAppender
                 }
 
                 currentTerminal.writer().flush();
-                return;
             }
             catch (IllegalStateException ignored)
             {
@@ -329,10 +328,13 @@ public class TerminalConsoleAppender extends AbstractAppender
                 // keeps logging during shutdown) before this log event was dispatched.
                 // Fall back to the saved standard output instead of failing the appender
                 // with "Terminal has been closed".
+                stdout.print(text);
             }
         }
-
-        stdout.print(text);
+        else
+        {
+            stdout.print(text);
+        }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/server/terminalconsole/TerminalConsoleAppender.java
+++ b/src/main/java/net/minecraftforge/server/terminalconsole/TerminalConsoleAppender.java
@@ -301,24 +301,38 @@ public class TerminalConsoleAppender extends AbstractAppender
 
     private synchronized void print(String text)
     {
-        if (terminal != null)
+        // Capture the shared terminal/reader into locals. close() and setReader()
+        // synchronize on the class, while this method synchronizes on the instance,
+        // so the fields can be cleared concurrently (e.g. during server shutdown).
+        Terminal currentTerminal = terminal;
+        LineReader currentReader = reader;
+        if (currentTerminal != null)
         {
-            if (reader != null)
+            try
             {
-                reader.printAbove(text);
-            }
-            else
-            {
-                terminal.writer().print(text);
-                terminal.writer().flush();
-            }
+                if (currentReader != null)
+                {
+                    currentReader.printAbove(text);
+                }
+                else
+                {
+                    currentTerminal.writer().print(text);
+                    currentTerminal.writer().flush();
+                }
 
-            terminal.writer().flush();
+                currentTerminal.writer().flush();
+                return;
+            }
+            catch (IllegalStateException ignored)
+            {
+                // The terminal was closed (typically while MinecraftServer.stopServer()
+                // keeps logging during shutdown) before this log event was dispatched.
+                // Fall back to the saved standard output instead of failing the appender
+                // with "Terminal has been closed".
+            }
         }
-        else
-        {
-            stdout.print(text);
-        }
+
+        stdout.print(text);
     }
 
     /**
@@ -341,6 +355,9 @@ public class TerminalConsoleAppender extends AbstractAppender
                 finally
                 {
                     terminal = null;
+                    // Drop the stale reader as well; it is bound to the now-closed
+                    // terminal and would otherwise throw on the next log event.
+                    reader = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Stops the `ERROR An exception occurred processing Appender Console / java.lang.IllegalStateException: Terminal has been closed` stack trace that log4j prints on every clean dedicated-server stop (#566). The shutdown already completed correctly, but the spurious trace was logged each time `stop` was typed.

## Why this matters

As the maintainer confirmed on the issue, `MinecraftServer.stopServer()` keeps logging ("Stopping server", "Saving players", ...) after the JLine terminal has already been closed during shutdown, so those log events are dispatched to a dead appender.

`TerminalConsoleAppender.print()` is `synchronized` on the instance, while `close()` and `setReader()` are `synchronized` on the class. Because they use different monitors, the static `terminal`/`reader` fields can be cleared, or the terminal closed, concurrently with a `print()` that has already passed its null check. The call then lands on `reader.printAbove(...)` / `terminal.writer().print(...)` against a closed terminal and throws `IllegalStateException: Terminal has been closed`.

The fix:

- `print()` captures the shared `terminal`/`reader` into locals (so a concurrent clear cannot turn the guard into an NPE) and wraps the JLine write in `try/catch (IllegalStateException)`, falling back to the saved `stdout` `PrintStream` exactly as the no-terminal branch already does. Late shutdown log lines still reach stdout instead of failing the appender.
- `close()` now also nulls the stale `reader` after closing the terminal, so a later event cannot reuse a `LineReader` bound to the closed terminal.

Normal runtime logging is unchanged: while the terminal is open and a `LineReader` is attached, `reader.printAbove(...)` is still used.

## Testing

- Reviewed the shutdown path: `TerminalHandler` only clears the reader in its `finally` after the read loop exits, so during `stopServer()` the reader/terminal can still be set while the terminal is being closed - the exact race the catch now absorbs.
- Confirmed the change is self-contained to `TerminalConsoleAppender` and that the open-terminal path (`reader.printAbove` / `terminal.writer()`) is preserved; only the closed-terminal case is rerouted to stdout.

Fixes #566
