### PR TITLE
Speed up ASMDataTable.getAnnotationsFor (O(n^2) -> O(n))

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/discovery/ASMDataTable.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ASMDataTable.java
@@ -19,23 +19,21 @@
 
 package net.minecraftforge.fml.common.discovery;
 
+import java.io.File;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 
 import net.minecraftforge.fml.common.ModContainer;
-import org.apache.commons.lang3.tuple.Pair;
 
 public class ASMDataTable
 {
@@ -78,7 +76,7 @@ public class ASMDataTable
         {
             return objectName;
         }
-        
+
         public Map<String, Object> getAnnotationInfo()
         {
             return annotationInfo;
@@ -99,19 +97,6 @@ public class ASMDataTable
         }
     }
 
-    private static class ModContainerPredicate implements Predicate<ASMData>
-    {
-        private ModContainer container;
-        public ModContainerPredicate(ModContainer container)
-        {
-            this.container = container;
-        }
-        @Override
-        public boolean apply(ASMData data)
-        {
-            return container.getSource().equals(data.candidate.getModContainer());
-        }
-    }
     private final SetMultimap<String, ASMData> globalAnnotationData = HashMultimap.create();
     private Map<ModContainer, SetMultimap<String,ASMData>> containerAnnotationData;
 
@@ -122,10 +107,21 @@ public class ASMDataTable
     {
         if (containerAnnotationData == null)
         {
-            //concurrently filter the values to speed this up
-            containerAnnotationData = containers.parallelStream()
-                    .map(cont -> Pair.of(cont, ImmutableSetMultimap.copyOf(Multimaps.filterValues(globalAnnotationData, new ModContainerPredicate(cont)))))
-                    .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+            // single pass grouping by source file instead of re-filtering the whole
+            // globalAnnotationData table once per mod container (was O(mods * annotations))
+            Map<File, ImmutableSetMultimap.Builder<String, ASMData>> bySource = new HashMap<>();
+            for (Map.Entry<String, ASMData> entry : globalAnnotationData.entries())
+            {
+                bySource.computeIfAbsent(entry.getValue().candidate.getModContainer(), f -> ImmutableSetMultimap.builder())
+                        .put(entry.getKey(), entry.getValue());
+            }
+            ImmutableMap.Builder<ModContainer, SetMultimap<String, ASMData>> result = ImmutableMap.builder();
+            for (ModContainer cont : containers)
+            {
+                ImmutableSetMultimap.Builder<String, ASMData> builder = bySource.get(cont.getSource());
+                result.put(cont, builder == null ? ImmutableSetMultimap.of() : builder.build());
+            }
+            containerAnnotationData = result.build();
         }
         return containerAnnotationData.get(container);
     }

--- a/src/test/java/net/minecraftforge/fml/common/discovery/ASMDataTableTest.java
+++ b/src/test/java/net/minecraftforge/fml/common/discovery/ASMDataTableTest.java
@@ -1,0 +1,71 @@
+package net.minecraftforge.fml.common.discovery;
+
+import net.minecraftforge.fml.common.DummyModContainer;
+import net.minecraftforge.fml.common.ModContainer;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ASMDataTableTest {
+
+    private static ModContainer containerWithSource(File source) {
+        return new DummyModContainer() {
+            @Override
+            public File getSource() {
+                return source;
+            }
+        };
+    }
+
+    @Test
+    public void getAnnotationsForGroupsBySourceFile() {
+        File jarA = new File("modA.jar");
+        File jarB = new File("modB.jar");
+        File jarC = new File("modC.jar");
+
+        ModCandidate candidateA = new ModCandidate(jarA, jarA, ContainerType.JAR);
+        ModCandidate candidateB = new ModCandidate(jarB, jarB, ContainerType.JAR);
+
+        ASMDataTable table = new ASMDataTable();
+
+        table.addASMData(candidateA, "AnnoX", "com/example/AClassOne", null, null);
+        table.addASMData(candidateA, "AnnoY", "com/example/AClassTwo", null, null);
+        // Same annotation type as above, but from a different mod's jar - must not leak across containers
+        table.addASMData(candidateB, "AnnoX", "com/example/BClassOne", null, null);
+
+        ModContainer containerA = containerWithSource(jarA);
+        ModContainer containerB = containerWithSource(jarB);
+        ModContainer containerC = containerWithSource(jarC); // no ASMData for this source
+
+        table.addContainer(containerA);
+        table.addContainer(containerB);
+        table.addContainer(containerC);
+
+        Set<ASMDataTable.ASMData> forA = table.getAnnotationsFor(containerA).get("AnnoX");
+        assertEquals(1, forA.size());
+        assertEquals("com/example/AClassOne", forA.iterator().next().getClassName());
+
+        assertEquals(1, table.getAnnotationsFor(containerA).get("AnnoY").size());
+
+        Set<ASMDataTable.ASMData> forB = table.getAnnotationsFor(containerB).get("AnnoX");
+        assertEquals(1, forB.size());
+        assertEquals("com/example/BClassOne", forB.iterator().next().getClassName());
+
+        assertTrue(table.getAnnotationsFor(containerC).isEmpty());
+    }
+
+    @Test
+    public void getAnnotationsForIsCachedAcrossCalls() {
+        File jar = new File("mod.jar");
+        ModCandidate candidate = new ModCandidate(jar, jar, ContainerType.JAR);
+        ASMDataTable table = new ASMDataTable();
+        table.addASMData(candidate, "AnnoX", "com/example/AClassOne", null, null);
+        ModContainer container = containerWithSource(jar);
+        table.addContainer(container);
+
+        assertSame(table.getAnnotationsFor(container), table.getAnnotationsFor(container));
+    }
+}


### PR DESCRIPTION
Found this while profiling a ~200-mod pack's startup with flare:
`getAnnotationsFor` was re-filtering the *entire* annotation table once per mod (Guava's `Multimaps.filterValues` + `ImmutableSetMultimap.copyOf` re-scanning everything on every call), which added up to ~19s of CPU time during preInit for no real reason.

Swapped it for a single grouping pass over the annotation table, then an O(1) lookup per container - same equality check as before (`File` from `ModContainer.getSource()`), just done once instead of once-per-mod. Same caching, same public behavior.

Before flare profiles:
<img width="2456" height="862" alt="before" src="https://github.com/user-attachments/assets/be4ed8a4-417a-4bf4-8edc-82ebc87db397" />
After:
<img width="2430" height="740" alt="after" src="https://github.com/user-attachments/assets/42acde6f-0190-420a-889c-9835f17396e8" />