### PR TITLE
fix cleanroomClient crash on macOS due to an unexpected exclusion of java-objc-bridge-1.2

### DIFF
--- a/projects/cleanroom/build.gradle
+++ b/projects/cleanroom/build.gradle
@@ -151,7 +151,7 @@ patcher {
                     '^lwjgl-2.*$',
                     '^lwjgl_util-2.*$',
                     '^lwjgl-platform-2.*$',
-                    '^java-objc-bridge-1.*$'
+                    '^java-objc-bridge-1.0.*$'
             ]
 
             classpathExclude(*legacyVanillaClasspathExclusions)


### PR DESCRIPTION
https://github.com/CleanroomMC/Cleanroom/commit/fd78c16fee1841d1765f80d738b527f3f57f7993