### PR TITLE
Fix query finish call on GUI close

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiConfirmation.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiConfirmation.java
@@ -43,9 +43,17 @@ public class GuiConfirmation extends GuiNotification
     {
         if (button.enabled && (button.id == 0 || button.id == 1))
         {
-            FMLClientHandler.instance().showGuiScreen(null);
             query.setResult(button.id == 0);
-            query.finish();
+            FMLClientHandler.instance().showGuiScreen(null);
         }
+    }
+
+    /**
+     * Called when the screen is unloaded. Used to disable keyboard repeat events
+     */
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        query.finish();
     }
 }

--- a/src/main/java/net/minecraftforge/fml/client/GuiConfirmation.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiConfirmation.java
@@ -47,13 +47,4 @@ public class GuiConfirmation extends GuiNotification
             FMLClientHandler.instance().showGuiScreen(null);
         }
     }
-
-    /**
-     * Called when the screen is unloaded. Used to disable keyboard repeat events
-     */
-    @Override
-    public void onGuiClosed() {
-        super.onGuiClosed();
-        query.finish();
-    }
 }

--- a/src/main/java/net/minecraftforge/fml/client/GuiNotification.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiNotification.java
@@ -43,7 +43,6 @@ public class GuiNotification extends GuiScreen
         if (button.enabled && button.id == 0)
         {
             FMLClientHandler.instance().showGuiScreen(null);
-            query.finish();
         }
     }
 
@@ -77,4 +76,10 @@ public class GuiNotification extends GuiScreen
     }
 
     protected final StartupQuery query;
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        query.finish();
+    }
 }


### PR DESCRIPTION
Ensure query.finish() is called when the GUI is closed.
fix #613